### PR TITLE
Add bambda to filter out proxy requests with the OPTIONS method.

### DIFF
--- a/Proxy/HTTP/FilterOutOptionsRequests.bambda
+++ b/Proxy/HTTP/FilterOutOptionsRequests.bambda
@@ -1,0 +1,7 @@
+/**
+ * Filter out OPTIONS requests.
+ *
+ * @author Trikster
+ **/
+
+return !requestResponse.request().method().equals("OPTIONS");


### PR DESCRIPTION
### Bambda Contributions

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an @author annotation and suitable description
* [x] Bambda is in the correct directory
* [x] Bambda compiles and executes as expected
