### PR TITLE
Bambda Script to Filter on a Specific Highlight Color

### DIFF
--- a/Proxy/HTTP/FilterOnSpecificHighlightColor.bambda
+++ b/Proxy/HTTP/FilterOnSpecificHighlightColor.bambda
@@ -1,0 +1,19 @@
+/**
+ * Filters requests/responses for specific highlight colors
+ *
+ * @author Nick Coblentz (https://github.com/ncoblentz)
+ * 
+ * You can currently filter requests/responses that are highlighted, but you can't ask Burp to show you requests/responses highlighted with a particular color only. If you use a specific color to categorize requests/responses for role-based authorization testing, todo lists, or identifying a particular browser tab/window then its helpful to be able to see only those requests/resposnse you are interested in. The following Bambda snippet lets you choose the color(s) you want to see. The available colors are:
+ * - HighlightColor.BLUE;
+ * - HighlightColor.CYAN;
+ * - HighlightColor.GRAY;
+ * - HighlightColor.GREEN;
+ * - HighlightColor.MAGENTA;
+ * - HighlightColor.NONE;
+ * - HighlightColor.ORANGE;
+ * - HighlightColor.PINK;
+ * - HighlightColor.RED;
+ * - HighlightColor.YELLOW;
+ **/
+
+ return requestResponse.annotations().highlightColor().equals(HighlightColor.CYAN);

--- a/Proxy/HTTP/FilterOnSpecificHighlightColor.bambda
+++ b/Proxy/HTTP/FilterOnSpecificHighlightColor.bambda
@@ -1,9 +1,14 @@
 /**
  * Filters requests/responses for specific highlight colors
  *
- * @author Nick Coblentz (https://github.com/ncoblentz)
+ * @author [Nick Coblentz](https://github.com/ncoblentz)
  * 
+ 
+ **/
+
+/* 
  * You can currently filter requests/responses that are highlighted, but you can't ask Burp to show you requests/responses highlighted with a particular color only. If you use a specific color to categorize requests/responses for role-based authorization testing, todo lists, or identifying a particular browser tab/window then its helpful to be able to see only those requests/resposnse you are interested in. The following Bambda snippet lets you choose the color(s) you want to see. The available colors are:
+ * Options:
  * - HighlightColor.BLUE;
  * - HighlightColor.CYAN;
  * - HighlightColor.GRAY;
@@ -14,6 +19,6 @@
  * - HighlightColor.PINK;
  * - HighlightColor.RED;
  * - HighlightColor.YELLOW;
- **/
+ */
 
  return requestResponse.annotations().highlightColor().equals(HighlightColor.CYAN);

--- a/Proxy/HTTP/README.md
+++ b/Proxy/HTTP/README.md
@@ -42,5 +42,33 @@ return false;
 ### Find role within JWT claims
 #### Author: Trikster
 ```java
+if (!requestResponse.hasResponse())
+{
+    return false;
+}
+
+var body = requestResponse.response().bodyToString().trim();
+
+if (requestResponse.response().hasHeader("authorization")) {
+    var authValue = requestResponse.response().headerValue("authorization");
+
+    if (authValue.startsWith("Bearer ey")) {
+        var tokens = authValue.split("\\.");
+
+        if (tokens.length == 3) {
+            var decodedClaims = utilities().base64Utils().decode(tokens[1], Base64DecodingOptions.URL).toString();
+
+            return decodedClaims.toLowerCase().contains("role");
+        }
+    }
+}
+
+return false;
+
+```
+## [FilterOnSpecificHighlightColor.bambda](https://github.com/PortSwigger/bambdas/blob/main/Proxy/HTTP/FilterOnSpecificHighlightColor.bambda)
+### Shows requests/responses highlighted with a specific color
+#### Author: [Nick Coblentz ](https://github.com/ncoblentz)
+```java
 return requestResponse.annotations().highlightColor().equals(HighlightColor.CYAN);
 ```

--- a/Proxy/HTTP/README.md
+++ b/Proxy/HTTP/README.md
@@ -42,27 +42,5 @@ return false;
 ### Find role within JWT claims
 #### Author: Trikster
 ```java
-if (!requestResponse.hasResponse())
-{
-    return false;
-}
-
-var body = requestResponse.response().bodyToString().trim();
-
-if (requestResponse.response().hasHeader("authorization")) {
-    var authValue = requestResponse.response().headerValue("authorization");
-
-    if (authValue.startsWith("Bearer ey")) {
-        var tokens = authValue.split("\\.");
-
-        if (tokens.length == 3) {
-            var decodedClaims = utilities().base64Utils().decode(tokens[1], Base64DecodingOptions.URL).toString();
-
-            return decodedClaims.toLowerCase().contains("role");
-        }
-    }
-}
-
-return false;
-
+return requestResponse.annotations().highlightColor().equals(HighlightColor.CYAN);
 ```

--- a/Proxy/HTTP/README.md
+++ b/Proxy/HTTP/README.md
@@ -66,9 +66,3 @@ if (requestResponse.response().hasHeader("authorization")) {
 return false;
 
 ```
-## [FilterOnSpecificHighlightColor.bambda](https://github.com/PortSwigger/bambdas/blob/main/Proxy/HTTP/FilterOnSpecificHighlightColor.bambda)
-### Shows requests/responses highlighted with a specific color
-#### Author: [Nick Coblentz ](https://github.com/ncoblentz)
-```java
-return requestResponse.annotations().highlightColor().equals(HighlightColor.CYAN);
-```


### PR DESCRIPTION
### Bambda Contributions

* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an @author annotation and suitable description
* [ ] Bambda is in the correct directory
* [ ] Bambda compiles and executes as expected
