### PR TITLE
Minor formatting fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,5 @@
 ### Bambda Contributions
 
-* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an @author annotation and suitable description
-* [ ] Bambda is in the correct directory
+* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
 * [ ] Bambda compiles and executes as expected
 * [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)

--- a/Proxy/HTTP/FilterOnSpecificHighlightColor.bambda
+++ b/Proxy/HTTP/FilterOnSpecificHighlightColor.bambda
@@ -1,12 +1,8 @@
 /**
  * Filters requests/responses for specific highlight colors
  *
- * @author [Nick Coblentz](https://github.com/ncoblentz)
+ * @author Nick Coblentz (https://github.com/ncoblentz)
  * 
- 
- **/
-
-/* 
  * You can currently filter requests/responses that are highlighted, but you can't ask Burp to show you requests/responses highlighted with a particular color only. If you use a specific color to categorize requests/responses for role-based authorization testing, todo lists, or identifying a particular browser tab/window then its helpful to be able to see only those requests/resposnse you are interested in. The following Bambda snippet lets you choose the color(s) you want to see. The available colors are:
  * Options:
  * - HighlightColor.BLUE;
@@ -19,6 +15,6 @@
  * - HighlightColor.PINK;
  * - HighlightColor.RED;
  * - HighlightColor.YELLOW;
- */
+ **/
 
  return requestResponse.annotations().highlightColor().equals(HighlightColor.CYAN);


### PR DESCRIPTION
Removes unintentional mention of `@author`.

Reverts javadoc for FilterOnSpecificHighlightColor.bambda - BambdaChecker has been updated to operate better with comments left below the author tag, so all info can remain in the top level javadoc.