### PR TITLE
Create OWASPTop25VulnerableParameters.bambda

### DIFF
--- a/Proxy/HTTP/OWASPTop25VulnerableParameters.bambda
+++ b/Proxy/HTTP/OWASPTop25VulnerableParameters.bambda
@@ -1,0 +1,48 @@
+/**
+ * Filters Proxy HTTP history for requests with vulnerable parameters based on the OWASP Top 25
+ * Author: Tur24Tur
+ * GitHub: @BugBountyzip BugBountyzip (https://github.com/BugBountyzip)
+ **/
+
+// Lists of vulnerable parameters based on OWASP Top 25
+String[] ssrfParams = {"dest=", "redirect=", "uri=", "path=", "continue=", "url=", "window=", "next=", "data=", "reference=", "site=", "html=", "val=", "validate=", "domain=", "callback=", "return=", "page=", "feed=", "host=", "port=", "to=", "out=", "view=", "dir="};
+String[] sqlParams = {"id=", "page=", "report=", "dir=", "search=", "category=", "file=", "class", "url=", "news=", "item=", "menu=", "lang=", "name=", "ref=", "title=", "view=", "topic=", "thread=", "type=", "date=", "form=", "main=", "nav=", "region="};
+String[] xssParams = {"q=", "s=", "search=", "id=", "lang=", "keyword=", "query=", "page=", "keywords=", "year=", "view=", "email=", "type=", "name=", "p=", "month=", "image=", "list_type=", "url=", "terms=", "categoryid=", "key=", "l=", "begindate=", "enddate="};
+String[] lfiParams = {"cat=", "dir=", "action=", "board=", "date=", "detail=", "file=", "download=", "path", "folder=", "prefix=", "include=", "page=", "inc=", "locate=", "show=", "doc=", "site=", "type=", "view=", "content=", "document=", "layout=", "mod=", "conf="};
+String[] orParams = {"next=", "url=", "target=", "rurl=", "dest=", "destination=", "redir=", "redirect_uri", "redirect_url=", "redirect=", "out=", "view=", "to=", "image_url=", "go=", "return=", "returnTo=", "return_to=", "checkout_url=", "continue=", "return_path="};
+String[] rceParams = {"cmd=", "exec=", "command=", "execute=", "ping=", "query=", "jump=", "code", "reg=", "do=", "func=", "arg=", "option=", "load=", "process=", "step=", "read=", "feature=", "exe=", "module=", "payload=", "run=", "print="};
+
+
+// Main logic of the Bambda
+if (requestResponse.request().url() != null) {
+    String requestUrl = requestResponse.request().url();
+    String requestBody = requestResponse.request().bodyToString();
+	
+// Consolidate all parameter lists into a single array for easier processing
+    String[][] allParams = {ssrfParams, sqlParams, xssParams, lfiParams, orParams, rceParams};
+
+// Extract the query string from the URL (if any)
+    int queryStart = requestUrl.indexOf("?");
+    String queryString = "";
+    if (queryStart != -1 && queryStart < requestUrl.length() - 1) {
+        queryString = requestUrl.substring(queryStart + 1);
+    }
+	
+// Combine and split the query string and request body into individual parameters
+    String[] allInputParams = (queryString + "&" + requestBody).split("&");
+
+    // Check each parameter against the lists of vulnerable parameters
+    for (String inputParam : allInputParams) {
+        for (String[] paramArray : allParams) {
+            for (String param : paramArray) {
+                if (inputParam.startsWith(param)) {
+                    return true; 
+                }
+            }
+        }
+    }
+}
+
+return false;
+
+


### PR DESCRIPTION
This `.bambda` file serves as a filter for the Burp Suite tool, identifying HTTP requests with parameters listed in the OWASP Top 25 vulnerabilities. It's designed to help security professionals quickly pinpoint potentially risky parameters.

### Bambda Contributions

* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [ ] Bambda compiles and executes as expected
* [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
