### PR TITLE
Create HighlightUnencryptedHTTP.bambda

### DIFF
--- a/Proxy/HTTP/HighlightUnencryptedHTTP.bambda
+++ b/Proxy/HTTP/HighlightUnencryptedHTTP.bambda
@@ -1,0 +1,20 @@
+/**
+ * Bambda Script to Highlight Unencrypted HTTP Traffic
+ * Filters Proxy HTTP history for unencrypted (non-HTTPS) requests.
+ * @author Tur24Tur / BugBountyzip (https://github.com/BugBountyzip)
+ **/
+
+// Get the request object from the requestResponse
+var request = requestResponse.request();
+
+// Extract the URL from the request
+var requestUrl = request.url();
+
+// Check if the request URL starts with "http://"
+if (requestUrl.startsWith("http://")) {
+    // URL is unencrypted, return true to highlight this request
+    return true;
+}
+
+// URL is encrypted or does not match the criteria, return false
+return false;


### PR DESCRIPTION
This Bambda script filters the Proxy history to identify and highlight unencrypted HTTP traffic. It's designed to pinpoint requests that are not secured with HTTPS.

### Bambda Contributions

* [x] Bambda compiles and executes as expected
* [x] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
