### PR TITLE
Add Bambdas from PS Research

### DIFF
--- a/Proxy/HTTP/GraphQlEndpoints.bambda
+++ b/Proxy/HTTP/GraphQlEndpoints.bambda
@@ -1,0 +1,32 @@
+/**
+ * Finds GraphQL endpoints with a 'query' parameter containing a newline.
+ * 
+ * @author Gareth Hayes
+ **/
+
+var req = requestResponse.request();
+
+if (!req.hasParameters()) {
+	return false;
+}
+
+var types = new HttpParameterType[] {
+    HttpParameterType.JSON, HttpParameterType.BODY, HttpParameterType.URL
+};
+
+for (HttpParameterType type : types) {
+    if (req.hasParameter("query", type)) {
+        var value = req.parameterValue("query", type);
+        if (type == HttpParameterType.JSON) {
+	        if (value.contains("\\n")) {
+                return true;
+            }
+        } else {
+            if (value.toLowerCase().contains("%0a")) {
+                return true;
+            }
+        }
+    }
+}
+
+return false;

--- a/Proxy/HTTP/IncorrectContentLength.bambda
+++ b/Proxy/HTTP/IncorrectContentLength.bambda
@@ -1,0 +1,10 @@
+/**
+ * Finds responses whose body length do not match their stated Content-Length header.
+ * 
+ * @author albinowax
+ **/
+
+int realContentLength = requestResponse.response().body().length();
+int declaredContentLength = Integer.parseInt(requestResponse.response().headerValue("Content-Length"));
+
+return declaredContentLength != realContentLength;

--- a/Proxy/HTTP/JSONPForCSPBypass.bambda
+++ b/Proxy/HTTP/JSONPForCSPBypass.bambda
@@ -1,0 +1,32 @@
+/**
+ * JSONP for CSP bypass.
+ * 
+ * @author Gareth Hayes
+ * 
+ * Finds scripts on the site that you can control because the CSP allows "same site" script resources.
+ **/
+
+var req = requestResponse.request();
+var res = requestResponse.response();
+var paramRegex = Pattern.compile("^[a-zA-Z][.\\w]{4,}$");
+
+if (res == null || res.body().length() == 0) return false;
+
+if (!req.hasParameters()) return false;
+
+var body = res.bodyToString().trim();
+var params = req.parameters();
+
+for (var param : params) {
+    var value = param.value();
+    if (param.type() != HttpParameterType.URL) continue;
+    if (paramRegex.matcher(value).find()) {
+        var start = "(?:^|[^\\w'\".])";
+        var end = "\\s*[(]";
+        var callbackRegex = Pattern.compile(start + Pattern.quote(value) + end);
+
+    	if (callbackRegex.matcher(body).find()) return true;
+    }
+}
+
+return false;

--- a/Proxy/HTTP/LargeRedirectResponses.bambda
+++ b/Proxy/HTTP/LargeRedirectResponses.bambda
@@ -1,0 +1,13 @@
+/**
+ * Flags redirect responses with a body over 1000 bytes.
+ * 
+ * @author albinowax
+ * 
+ * Can indicate sites that forgot to terminate script execution when the user fails
+ * authentication, typically leading to information disclosure.
+ **/
+
+return requestResponse.hasResponse() &&
+       requestResponse.response().statusCode() <= 399 &&
+       requestResponse.response().statusCode() >= 300 &&
+       requestResponse.response().body().length() > 1000;

--- a/Proxy/HTTP/MalformedHttpHeader.bambda
+++ b/Proxy/HTTP/MalformedHttpHeader.bambda
@@ -1,0 +1,8 @@
+/**
+ * Finds malformed HTTP headers containing spaces within their names.
+ * 
+ * @author albinowax
+ **/
+
+return requestResponse.response().headers().stream()
+    .anyMatch(e -> e.name().contains(" "));

--- a/Proxy/HTTP/MultipleHtmlTags.bambda
+++ b/Proxy/HTTP/MultipleHtmlTags.bambda
@@ -1,0 +1,9 @@
+/**
+ * Finds responses with multiple HTML closing tags.
+ * 
+ * @author albinowax
+ **/
+
+return requestResponse.response().statedMimeType() == MimeType.HTML &&
+       utilities().byteUtils().countMatches(
+       requestResponse.response().body().getBytes(), "</html>".getBytes()) > 1;

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ Developed both by PortSwigger and the community with 🧡
 ## Bambda Categories
 - [Proxy HTTP filters](https://github.com/PortSwigger/bambdas/tree/main/Proxy/HTTP)
 
-## Documentation
+## Documentation & Resources
 Online documentation for Proxy HTTP Bambdas can be found [here](https://portswigger.net/burp/documentation/desktop/tools/proxy/http-history/bambdas).
 
 - [Introducing Bambdas](https://portswigger.net/blog/introducing-bambdas)
 - [Burp Suite Shorts | Bambdas](https://www.youtube.com/watch?v=neQpukwW43g)
+- [Finding that one weird endpoint, with Bambdas](https://portswigger.net/research/finding-that-one-weird-endpoint-with-bambdas)
 
 ## Community Submissions
 Please issue a pull request and follow the process outlined [here](https://github.com/PortSwigger/Bambdas/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
### Bambda Contributions

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [x] Bambda compiles and executes as expected
* [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
