### PR TITLE
Update MultipleHtmlTags.bambda

### DIFF
--- a/Proxy/HTTP/MultipleHtmlTags.bambda
+++ b/Proxy/HTTP/MultipleHtmlTags.bambda
@@ -1,9 +1,23 @@
 /**
  * Finds responses with multiple HTML closing tags.
  * 
- * @author albinowax
+ * @author albinowax & PortSwiggerWiener
  **/
 
-return requestResponse.response().statedMimeType() == MimeType.HTML &&
-       utilities().byteUtils().countMatches(
-       requestResponse.response().body().getBytes(), "</html>".getBytes()) > 1;
+// Main logic of the Bambda
+if (requestResponse.request().url() != null && requestResponse.hasResponse()) {
+    // Check if the response has HTML content type and multiple </html> tags
+    if (requestResponse.response().statedMimeType() == MimeType.HTML &&
+        utilities().byteUtils().countMatches(requestResponse.response().body().getBytes(), "</html>".getBytes()) > 1) {
+
+        // Add a note indicating that multiple </html> tags were detected
+        requestResponse.annotations().setNotes("Multiple </html> tags detected");
+
+        // Highlight the request/response and return true to indicate that the condition was met
+        requestResponse.annotations().setHighlightColor(HighlightColor.YELLOW);
+        return true;
+    }
+}
+
+// Return false if no multiple </html> tags were found or other conditions are not met
+return false;

--- a/Proxy/HTTP/MultipleHtmlTags.bambda
+++ b/Proxy/HTTP/MultipleHtmlTags.bambda
@@ -1,23 +1,10 @@
 /**
  * Finds responses with multiple HTML closing tags.
  * 
- * @author albinowax & PortSwiggerWiener
+ * @author albinowax
  **/
 
-// Main logic of the Bambda
-if (requestResponse.request().url() != null && requestResponse.hasResponse()) {
-    // Check if the response has HTML content type and multiple </html> tags
-    if (requestResponse.response().statedMimeType() == MimeType.HTML &&
-        utilities().byteUtils().countMatches(requestResponse.response().body().getBytes(), "</html>".getBytes()) > 1) {
-
-        // Add a note indicating that multiple </html> tags were detected
-        requestResponse.annotations().setNotes("Multiple </html> tags detected");
-
-        // Highlight the request/response and return true to indicate that the condition was met
-        requestResponse.annotations().setHighlightColor(HighlightColor.YELLOW);
-        return true;
-    }
-}
-
-// Return false if no multiple </html> tags were found or other conditions are not met
-return false;
+return requestResponse.hasResponse() &&
+       requestResponse.response().statedMimeType() == MimeType.HTML &&
+       utilities().byteUtils().countMatches(
+       requestResponse.response().body().getBytes(), "</html>".getBytes()) > 1;


### PR DESCRIPTION

![image](https://github.com/PortSwigger/bambdas/assets/133497067/73f6a047-8cbe-4f0c-b53e-045ffafe01d6)

``
An exception was thrown while running your Bambda for item number 521

java.lang.NullPointerException: Cannot invoke "burp.api.montoya.http.message.responses.HttpResponse.statedMimeType()" because the return value of "burp.api.montoya.proxy.ProxyHttpRequestResponse.response()" is null
	at burp.Bambda.matches(Bambda.java:42)
``

The problem initially encountered with the Bambda script involved a `NullPointerException`. This exception was thrown because the script attempted to invoke the `statedMimeType()` method on a `HttpResponse` object that was null. This issue typically occurs when the script is trying to process an HTTP transaction (request/response pair) where the response part is missing or not properly captured.

To address this issue, the script was modified to include a check ensuring that both the request and response objects are not null before proceeding with the processing. This ensures that the script only attempts to process complete HTTP transactions where both the request and response are available. 

also an enhancement was made to the script to detect multiple `</html>` tags in HTML responses. This was done by counting the occurrences of `</html>` in the response body and highlighting the transactions where more than one occurrence was found. This feature is useful for identifying responses that may contain improperly structured HTML, which could be indicative of potential issues or vulnerabilities.

Thank you



### Bambda Contributions

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [x] Bambda compiles and executes as expected
* [x] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
