### PR TITLE
Bug fix on IncorrectContentLength.bambda

### DIFF
--- a/Proxy/HTTP/IncorrectContentLength.bambda
+++ b/Proxy/HTTP/IncorrectContentLength.bambda
@@ -1,33 +1,14 @@
 /**
  * Finds responses whose body length do not match their stated Content-Length header.
  * 
- * @author albinowax & PortSwiggerWiener  <3
+ * @author albinowax
  **/
 
-
-if (requestResponse.request().url() != null && requestResponse.hasResponse()) {
-    HttpResponse response = requestResponse.response();
-
-    // Check if Content-Length header is present
-    String contentLengthHeader = response.headerValue("Content-Length");
-    if (contentLengthHeader != null) {
-        try {
-            int declaredContentLength = Integer.parseInt(contentLengthHeader);
-            int realContentLength = response.body().length();
-
-            // Check for mismatch between declared and actual content length
-            if (declaredContentLength != realContentLength) {
-                // Mismatch found, highlight and return true
-                requestResponse.annotations().setHighlightColor(HighlightColor.YELLOW);
-                requestResponse.annotations().setNotes("Content-Length mismatch detected");
-                return true;
-            }
-        } catch (NumberFormatException e) {
-            // Handle potential number format exception
-            e.printStackTrace();
-        }
-    }
+if (!requestResponse.hasResponse()) {
+    return false;
 }
 
-// No Content-Length mismatch found or no Content-Length header
-return false;
+int realContentLength = requestResponse.response().body().length();
+int declaredContentLength = Integer.parseInt(requestResponse.response().headerValue("Content-Length"));
+
+return declaredContentLength != realContentLength;

--- a/Proxy/HTTP/IncorrectContentLength.bambda
+++ b/Proxy/HTTP/IncorrectContentLength.bambda
@@ -1,10 +1,33 @@
 /**
  * Finds responses whose body length do not match their stated Content-Length header.
  * 
- * @author albinowax
+ * @author albinowax & PortSwiggerWiener  <3
  **/
 
-int realContentLength = requestResponse.response().body().length();
-int declaredContentLength = Integer.parseInt(requestResponse.response().headerValue("Content-Length"));
 
-return declaredContentLength != realContentLength;
+if (requestResponse.request().url() != null && requestResponse.hasResponse()) {
+    HttpResponse response = requestResponse.response();
+
+    // Check if Content-Length header is present
+    String contentLengthHeader = response.headerValue("Content-Length");
+    if (contentLengthHeader != null) {
+        try {
+            int declaredContentLength = Integer.parseInt(contentLengthHeader);
+            int realContentLength = response.body().length();
+
+            // Check for mismatch between declared and actual content length
+            if (declaredContentLength != realContentLength) {
+                // Mismatch found, highlight and return true
+                requestResponse.annotations().setHighlightColor(HighlightColor.YELLOW);
+                requestResponse.annotations().setNotes("Content-Length mismatch detected");
+                return true;
+            }
+        } catch (NumberFormatException e) {
+            // Handle potential number format exception
+            e.printStackTrace();
+        }
+    }
+}
+
+// No Content-Length mismatch found or no Content-Length header
+return false;


### PR DESCRIPTION

![image](https://github.com/PortSwigger/bambdas/assets/133497067/e6c0cda0-149d-4e5e-9d8a-11265341ac83)

```
An exception was thrown while running your Bambda for item number 2

java.lang.NumberFormatException: Cannot parse null string
	at java.base/java.lang.Integer.parseInt(Integer.java:627)
	at java.base/java.lang.Integer.parseInt(Integer.java:781)
```

The original script faced an issue where it attempted to parse the `Content-Length` header value as an integer without checking if the header was actually present. This led to a `NumberFormatException` when the header was missing, as it tried to parse a `null` string.

To fix this, I added a check to ensure that the `Content-Length` header exists before parsing it. If the header is missing, the script skips the parsing step, thereby avoiding the `NumberFormatException`. Additionally, I included a `try-catch` block to gracefully handle any potential number format exceptions that might occur if the header value is not a valid integer. This made the script more robust and error-resistant.

### Bambda Contributions

* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [ ] Bambda compiles and executes as expected
* [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
