### PR TITLE
Added bamda that finds hostnames in responses

### DIFF
--- a/Proxy/HTTP/HostnameInResponse.bamda
+++ b/Proxy/HTTP/HostnameInResponse.bamda
@@ -1,0 +1,12 @@
+/**
+ * Finds responses which contain the hostname.
+ *
+ * Useful to identify possible attack surface for host header injection and
+ * web cache poisioning attacks.
+ *
+ * @author emanuelduss
+ **/
+
+var hostname = requestResponse.request().headerValue("Host");
+
+return requestResponse.hasResponse() && requestResponse.response().contains(hostname, false);


### PR DESCRIPTION
### Bambda Contributions

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [x] Bambda compiles and executes as expected
* [x] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)

### Description

This bambda finds responses that contain the hostname. Useful to identify possible attack surface for host header injection and web cache poisioning attacks.