### PR TITLE
Added bambda that finds requests which reflect parameters in responses

### DIFF
--- a/Proxy/HTTP/ReflectedParameters.bambda
+++ b/Proxy/HTTP/ReflectedParameters.bambda
@@ -1,0 +1,53 @@
+/**
+ * Finds responses which reflect parameter names and values.
+ *
+ * Useful to identify possible attack surface for XSS, SSTI, header injection,
+ * open redirects or similar.
+ *
+ * @author emanuelduss
+ **/
+
+// Configure to your needs
+int minimumParameterNameLength = 2;
+int minimumParameterValueLength = 3;
+boolean matchCaseSensitive = true;
+Set<String> excludedStrings = Set.of("true", "false", "null");
+Set<HttpParameterType> excludedParameterTypes = Set.of(HttpParameterType.COOKIE); // e.g. HttpParameterType.COOKIE
+
+if (!requestResponse.hasResponse()){
+    return false;
+}
+
+HttpRequest request = requestResponse.request();
+HttpResponse response = requestResponse.response();
+
+// Check query, b/c parameters without values are not treated as parameters
+String query = request.path().replace(request.pathWithoutQuery() + "?", "");
+if (query.length() >= minimumParameterValueLength && !excludedStrings.contains(query)){
+    if (response.contains(query, matchCaseSensitive) || response.contains(utilities().urlUtils().decode(query), matchCaseSensitive)){
+        return true;
+    }
+}
+
+if (request.hasParameters()){
+    for (ParsedHttpParameter parameter : request.parameters()){
+        HttpParameterType parameterType = parameter.type();
+        if (excludedParameterTypes.contains(parameter.type())){
+            continue;
+        }
+
+        String parameterName = parameter.name();
+        if (parameterName.length() >= minimumParameterNameLength && ! excludedStrings.contains(parameterName) &&
+            (response.contains(parameterName, matchCaseSensitive) || response.contains(utilities().urlUtils().decode(parameterName), matchCaseSensitive))){
+            return true;
+        }
+
+        String parameterValue = parameter.value();
+        if (parameterValue.length() >= minimumParameterValueLength && ! excludedStrings.contains(parameterValue) &&
+            (response.contains(parameterValue, matchCaseSensitive) || response.contains(utilities().urlUtils().decode(parameterValue), matchCaseSensitive))){
+            return true;
+        }
+    }
+}
+
+return false;


### PR DESCRIPTION
Hi

This bambda finds responses which reflect parameter names and values.

Useful to identify possible attack surface for XSS, SSTI, header injection, open redirects or similar.

### Bambda Contributions

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [x] Bambda compiles and executes as expected
* [x] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)


Best,
Mänu