### PR TITLE
Bambdas to find URLs in requests and redirect parameters

### DIFF
--- a/Proxy/HTTP/RedirectedToParameterValue.bambda
+++ b/Proxy/HTTP/RedirectedToParameterValue.bambda
@@ -17,7 +17,7 @@ HttpResponse response = requestResponse.response();
 if (request.hasParameters() && response.isStatusCodeClass(StatusCodeClass.CLASS_3XX_REDIRECTION)){
     for (ParsedHttpParameter parameter : request.parameters()){
         String parameterValue = parameter.value();
-        if (response.hasHeader("Location", parameterValue) || 
+        if (response.hasHeader("Location", parameterValue) ||
             response.hasHeader("Location", utilities().urlUtils().encode(parameterValue)) ||
             response.hasHeader("Location", utilities().urlUtils().decode(parameterValue))){
             return true;

--- a/Proxy/HTTP/RedirectedToParameterValue.bambda
+++ b/Proxy/HTTP/RedirectedToParameterValue.bambda
@@ -1,0 +1,28 @@
+/**
+ * Finds responses which redirect to locations provided as GET parameters.
+ *
+ * Useful to identify possible attack surface for open redirects. This can be
+ * used for phishing, CSP bypasses or OAuth token stealing.
+ *
+ * @author emanuelduss
+ **/
+
+if (!requestResponse.hasResponse()){
+    return false;
+}
+
+HttpRequest request = requestResponse.request();
+HttpResponse response = requestResponse.response();
+
+if (request.hasParameters() && response.isStatusCodeClass(StatusCodeClass.CLASS_3XX_REDIRECTION)){
+    for (ParsedHttpParameter parameter : request.parameters()){
+        String parameterValue = parameter.value();
+        if (response.hasHeader("Location", parameterValue) || 
+            response.hasHeader("Location", utilities().urlUtils().encode(parameterValue)) ||
+            response.hasHeader("Location", utilities().urlUtils().decode(parameterValue))){
+            return true;
+        }
+    }
+}
+
+return false;

--- a/Proxy/HTTP/UrlInRequest.bambda
+++ b/Proxy/HTTP/UrlInRequest.bambda
@@ -7,15 +7,14 @@
  **/
 
 HttpRequest request = requestResponse.request();
-HttpResponse response = requestResponse.response();
 
 if (request.hasParameters()){
     for (ParsedHttpParameter parameter : request.parameters()){
         String parameterValue = parameter.value();
-        if (parameter.value().contains("http://") || 
-            parameter.value().contains(utilities().urlUtils().encode("http://")) ||
-            parameter.value().contains("https://") || 
-            parameter.value().contains(utilities().urlUtils().encode("https://"))){
+        if (parameterValue.contains("http://") ||
+            parameterValue.contains(utilities().urlUtils().encode("http://")) ||
+            parameterValue.contains("https://") ||
+            parameterValue.contains(utilities().urlUtils().encode("https://"))){
             return true;
         }
     }

--- a/Proxy/HTTP/UrlInRequest.bambda
+++ b/Proxy/HTTP/UrlInRequest.bambda
@@ -1,0 +1,24 @@
+/**
+ * Finds requests containing URLs.
+ *
+ * Useful to identify possible attack surface for SSRF.
+ *
+ * @author emanuelduss
+ **/
+
+HttpRequest request = requestResponse.request();
+HttpResponse response = requestResponse.response();
+
+if (request.hasParameters()){
+    for (ParsedHttpParameter parameter : request.parameters()){
+        String parameterValue = parameter.value();
+        if (parameter.value().contains("http://") || 
+            parameter.value().contains(utilities().urlUtils().encode("http://")) ||
+            parameter.value().contains("https://") || 
+            parameter.value().contains(utilities().urlUtils().encode("https://"))){
+            return true;
+        }
+    }
+}
+
+return false;


### PR DESCRIPTION
Hi

These bambdas can be used to find URLs in requests and parameters used for redirects.

### Bambda Contributions

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [x] Bambda compiles and executes as expected
* [x] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)

Best,
Mänu