### PR TITLE
Bambda to Filter Authenticated Requests

### DIFF
--- a/Proxy/HTTP/FilterAuthenticated.bambda
+++ b/Proxy/HTTP/FilterAuthenticated.bambda
@@ -1,0 +1,66 @@
+/**
+ * Filters authenticated 200 OK requests in Proxy HTTP history. See four config values below.
+ *
+ * @author joe-ds (https://github.com/joe-ds)
+ **/
+
+if (!requestResponse.hasResponse()) {
+    return false;
+}
+
+var configNoFilter = true;        // If set to false, won't show JS, GIF, JPG, PNG, CSS.
+var configNotInScopeOnly = true;  // If set to false, won't show out-of-scope items.
+var sessionCookieName = "";       // If given, will look for a cookie with that name.
+var sessionCookieValue = "";      // If given, will check if cookie with sessionCookieName has this value.
+
+var request = requestResponse.request();
+var response = requestResponse.response();
+var mimeType = requestResponse.mimeType();
+var path = requestResponse.request().pathWithoutQuery().toLowerCase();
+
+var inScope = requestResponse.request().isInScope();
+
+var isAuthorised = response.isStatusCodeClass(StatusCodeClass.CLASS_2XX_SUCCESS);
+var authHeader = request.hasHeader("Authorization");
+
+var sessionCookie = false;
+if (request.headerValue("Cookie") != null) {
+    if ((sessionCookieName.length() > 0) && (sessionCookieValue.length() > 0)) {
+        if (requestResponse.request().hasParameter(sessionCookieName, HttpParameterType.COOKIE)) {
+	        sessionCookie = requestResponse.request().parameter(sessionCookieName, HttpParameterType.COOKIE).value().equals(sessionCookieValue);
+        } else {
+            sessionCookie = false;
+        }
+    } else if (sessionCookieName.length() > 0) {
+        if (requestResponse.request().hasParameter(sessionCookieName, HttpParameterType.COOKIE)) {
+	        sessionCookie = true;
+        } else {
+            sessionCookie = false;
+        }
+    } else {
+        sessionCookie = false;
+    };
+} else {
+    sessionCookie = false;
+}
+
+var filterDenyList = mimeType != MimeType.CSS
+ && mimeType != MimeType.IMAGE_UNKNOWN
+ && mimeType != MimeType.IMAGE_JPEG
+ && mimeType != MimeType.IMAGE_GIF
+ && mimeType != MimeType.IMAGE_PNG
+ && mimeType != MimeType.IMAGE_BMP
+ && mimeType != MimeType.IMAGE_TIFF
+ && mimeType != MimeType.UNRECOGNIZED
+ && mimeType != MimeType.SOUND
+ && mimeType != MimeType.VIDEO
+ && mimeType != MimeType.FONT_WOFF
+ && mimeType != MimeType.FONT_WOFF2
+ && mimeType != MimeType.APPLICATION_UNKNOWN
+ && !path.endsWith(".js")
+ && !path.endsWith(".gif")
+ && !path.endsWith(".jpg")
+ && !path.endsWith(".png")
+ && !path.endsWith(".css");
+
+return isAuthorised && (authHeader || sessionCookie) && (configNoFilter || filterDenyList) && (configNotInScopeOnly || inScope);

--- a/Proxy/HTTP/FilterAuthenticated.bambda
+++ b/Proxy/HTTP/FilterAuthenticated.bambda
@@ -4,10 +4,14 @@
  * @author joe-ds (https://github.com/joe-ds)
  **/
 
+if (!requestResponse.hasResponse()) {
+    return false;
+}
+
 var request = requestResponse.request();
 var response = requestResponse.response();
 
-if (!response.isStatusCodeClass(StatusCodeClass.CLASS_2XX_SUCCESS) || !requestResponse.hasResponse()) {
+if (!response.isStatusCodeClass(StatusCodeClass.CLASS_2XX_SUCCESS)) {
     return false;
 }
 
@@ -16,7 +20,6 @@ var configNotInScopeOnly = true;  // If set to false, won't show out-of-scope it
 var sessionCookieName = "";       // If given, will look for a cookie with that name.
 var sessionCookieValue = "";      // If given, will check if cookie with sessionCookieName has this value.
 
-var inScope = request.isInScope();
 var authHeader = request.hasHeader("Authorization");
 
 boolean sessionCookie = request.headerValue("Cookie") != null
@@ -24,7 +27,7 @@ boolean sessionCookie = request.headerValue("Cookie") != null
                             && request.hasParameter(sessionCookieName, HttpParameterType.COOKIE) 
 			                && (sessionCookieValue.isEmpty() || sessionCookieValue.equals(request.parameter(sessionCookieName, HttpParameterType.COOKIE).value()));
 
-var path = requestResponse.request().pathWithoutQuery().toLowerCase();
+var path = request.pathWithoutQuery().toLowerCase();
 var mimeType = requestResponse.mimeType();
 var filterDenyList = mimeType != MimeType.CSS
  && mimeType != MimeType.IMAGE_UNKNOWN
@@ -45,4 +48,4 @@ var filterDenyList = mimeType != MimeType.CSS
  && !path.endsWith(".png")
  && !path.endsWith(".css");
 
-return (authHeader || sessionCookie) && (configNoFilter || filterDenyList) && (configNotInScopeOnly || inScope);
+return (authHeader || sessionCookie) && (configNoFilter || filterDenyList) && (configNotInScopeOnly || request.isInScope());

--- a/Proxy/HTTP/FilterAuthenticated.bambda
+++ b/Proxy/HTTP/FilterAuthenticated.bambda
@@ -4,6 +4,11 @@
  * @author joe-ds (https://github.com/joe-ds)
  **/
 
+var configNoFilter = true;        // If set to false, won't show JS, GIF, JPG, PNG, CSS.
+var configNotInScopeOnly = true;  // If set to false, won't show out-of-scope items.
+var sessionCookieName = "";       // If given, will look for a cookie with that name.
+var sessionCookieValue = "";      // If given, will check if cookie with sessionCookieName has this value.
+
 if (!requestResponse.hasResponse()) {
     return false;
 }
@@ -14,11 +19,6 @@ var response = requestResponse.response();
 if (!response.isStatusCodeClass(StatusCodeClass.CLASS_2XX_SUCCESS)) {
     return false;
 }
-
-var configNoFilter = true;        // If set to false, won't show JS, GIF, JPG, PNG, CSS.
-var configNotInScopeOnly = true;  // If set to false, won't show out-of-scope items.
-var sessionCookieName = "";       // If given, will look for a cookie with that name.
-var sessionCookieValue = "";      // If given, will check if cookie with sessionCookieName has this value.
 
 var authHeader = request.hasHeader("Authorization");
 

--- a/Proxy/HTTP/FilterAuthenticated.bambda
+++ b/Proxy/HTTP/FilterAuthenticated.bambda
@@ -4,7 +4,10 @@
  * @author joe-ds (https://github.com/joe-ds)
  **/
 
-if (!requestResponse.hasResponse()) {
+var request = requestResponse.request();
+var response = requestResponse.response();
+
+if (!response.isStatusCodeClass(StatusCodeClass.CLASS_2XX_SUCCESS) || !requestResponse.hasResponse()) {
     return false;
 }
 
@@ -13,37 +16,16 @@ var configNotInScopeOnly = true;  // If set to false, won't show out-of-scope it
 var sessionCookieName = "";       // If given, will look for a cookie with that name.
 var sessionCookieValue = "";      // If given, will check if cookie with sessionCookieName has this value.
 
-var request = requestResponse.request();
-var response = requestResponse.response();
-var mimeType = requestResponse.mimeType();
-var path = requestResponse.request().pathWithoutQuery().toLowerCase();
-
-var inScope = requestResponse.request().isInScope();
-
-var isAuthorised = response.isStatusCodeClass(StatusCodeClass.CLASS_2XX_SUCCESS);
+var inScope = request.isInScope();
 var authHeader = request.hasHeader("Authorization");
 
-var sessionCookie = false;
-if (request.headerValue("Cookie") != null) {
-    if ((sessionCookieName.length() > 0) && (sessionCookieValue.length() > 0)) {
-        if (requestResponse.request().hasParameter(sessionCookieName, HttpParameterType.COOKIE)) {
-	        sessionCookie = requestResponse.request().parameter(sessionCookieName, HttpParameterType.COOKIE).value().equals(sessionCookieValue);
-        } else {
-            sessionCookie = false;
-        }
-    } else if (sessionCookieName.length() > 0) {
-        if (requestResponse.request().hasParameter(sessionCookieName, HttpParameterType.COOKIE)) {
-	        sessionCookie = true;
-        } else {
-            sessionCookie = false;
-        }
-    } else {
-        sessionCookie = false;
-    };
-} else {
-    sessionCookie = false;
-}
+boolean sessionCookie = request.headerValue("Cookie") != null
+                            && !sessionCookieName.isEmpty()
+                            && request.hasParameter(sessionCookieName, HttpParameterType.COOKIE) 
+			                && (sessionCookieValue.isEmpty() || sessionCookieValue.equals(request.parameter(sessionCookieName, HttpParameterType.COOKIE).value()));
 
+var path = requestResponse.request().pathWithoutQuery().toLowerCase();
+var mimeType = requestResponse.mimeType();
 var filterDenyList = mimeType != MimeType.CSS
  && mimeType != MimeType.IMAGE_UNKNOWN
  && mimeType != MimeType.IMAGE_JPEG
@@ -63,4 +45,4 @@ var filterDenyList = mimeType != MimeType.CSS
  && !path.endsWith(".png")
  && !path.endsWith(".css");
 
-return isAuthorised && (authHeader || sessionCookie) && (configNoFilter || filterDenyList) && (configNotInScopeOnly || inScope);
+return (authHeader || sessionCookie) && (configNoFilter || filterDenyList) && (configNotInScopeOnly || inScope);


### PR DESCRIPTION
### Bambda Contributions

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [x] Bambda compiles and executes as expected
* [x] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)

This is a Bambda to filter 200 OK authenticated requests. It has four variables near the top. By default it looks for Authorization headers, but setting a session cookie name (and optionally value) means it also checks for these.