### PR TITLE
Create HighlightListenerPort.bambda

### DIFF
--- a/Proxy/HTTP/HighlightListenerPort.bambda
+++ b/Proxy/HTTP/HighlightListenerPort.bambda
@@ -1,0 +1,31 @@
+/**
+ * Highlight different listener port
+ * @author Bogo-6 (https://github.com/Bogo-6)
+ **/
+
+boolean manualColorHighlightEnabled = true;
+
+var listenerPort = requestResponse.listenerPort();
+
+
+if (listenerPort == 8080) {
+    if (manualColorHighlightEnabled){
+        requestResponse.annotations().setHighlightColor(HighlightColor.BLUE);
+
+        //Optionally, add a note to the request.
+        requestResponse.annotations().setNotes("User 1");
+    }
+    return true;
+}
+
+if (listenerPort == 8082) {
+    if (manualColorHighlightEnabled){
+        requestResponse.annotations().setHighlightColor(HighlightColor.YELLOW);
+        
+        //Optionally, add a note to the request.
+        requestResponse.annotations().setNotes("User 2");
+    }
+    return true;
+}
+
+return false;


### PR DESCRIPTION
Just a highlighter in case you use more listener ports.

### Bambda Contributions

* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [ ] Bambda compiles and executes as expected
* [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
