### PR TITLE
feat: highlight easy param miner requests

### DIFF
--- a/Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda
+++ b/Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda
@@ -8,17 +8,14 @@
 
  var configNoFilter = false;        // if set to false, won't show JS, GIF, JPG, PNG, CSS.
  var configInScopeOnly = true;      // if set to true, won't show out-of-scope items
- var request = requestResponse.request(); // create a var for request
- var response = requestResponse.response(); // create a var for response
- 
- // Early return conditions
- if (configInScopeOnly && !request.isInScope()) {
-     return false;
- }
- 
- if (response == null || !response.isStatusCodeClass(StatusCodeClass.CLASS_2XX_SUCCESS)) {
-     return false; // return only status codes of 2xx
- }
+
+ if (!requestResponse.hasResponse() || (configInScopeOnly && !requestResponse.request().isInScope()) || !requestResponse.response().isStatusCodeClass(StatusCodeClass.CLASS_2XX_SUCCESS))  
+{  
+    return false;  
+}  
+
+var request = requestResponse.request();  
+var response = requestResponse.response();  
  
  // Process path and mimeType for filtering
  var path = request.pathWithoutQuery().toLowerCase();

--- a/Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda
+++ b/Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda
@@ -6,28 +6,52 @@
  * @author GangGreenTemperTatum (https://github.com/GangGreenTemperTatum)
  **/
 
-var configNoFilter = false;        // if set to false, won't show JS, GIF, JPG, PNG, CSS.
-var configInScopeOnly = true;      // if set to true, won't show out-of-scope items
-var request = requestResponse.request(); // create a var for request
-var response = requestResponse.response(); // create a var for response
-
-if (configInScopeOnly && !request.isInScope()) {
-    return false;
-}
-
-if (response == null || !response.isStatusCodeClass(StatusCodeClass.CLASS_2XX_SUCCESS)) {
-    return false; // return only status codes of 2xx
-}
-
-// verify that the request is a POST, PUT, or PATCH
-if (!requestResponse.hasResponse() || request.method().equals("POST") || request.method().equals("PATCH") || request.method().equals("PUT")) {
-    // verify that the response is json
-    var contentType = response.headerValue("Content-Type");
-
-    // verify the content-type is json
-    if (contentType != null && contentType.contains("application/json")) {
-        return true;
-    }
-}
-
-return false; // This line ensures the method returns a boolean value
+ var configNoFilter = false;        // if set to false, won't show JS, GIF, JPG, PNG, CSS.
+ var configInScopeOnly = true;      // if set to true, won't show out-of-scope items
+ var request = requestResponse.request(); // create a var for request
+ var response = requestResponse.response(); // create a var for response
+ 
+ // Early return conditions
+ if (configInScopeOnly && !request.isInScope()) {
+     return false;
+ }
+ 
+ if (response == null || !response.isStatusCodeClass(StatusCodeClass.CLASS_2XX_SUCCESS)) {
+     return false; // return only status codes of 2xx
+ }
+ 
+ // Process path and mimeType for filtering
+ var path = request.pathWithoutQuery().toLowerCase();
+ var mimeType = requestResponse.mimeType();
+ var filterDenyList = mimeType != MimeType.CSS
+  && mimeType != MimeType.IMAGE_UNKNOWN
+  && mimeType != MimeType.IMAGE_JPEG
+  && mimeType != MimeType.IMAGE_GIF
+  && mimeType != MimeType.IMAGE_PNG
+  && mimeType != MimeType.IMAGE_BMP
+  && mimeType != MimeType.IMAGE_TIFF
+  && mimeType != MimeType.UNRECOGNIZED
+  && mimeType != MimeType.SOUND
+  && mimeType != MimeType.VIDEO
+  && mimeType != MimeType.FONT_WOFF
+  && mimeType != MimeType.FONT_WOFF2
+  && mimeType != MimeType.APPLICATION_UNKNOWN
+  && !path.endsWith(".js")
+  && !path.endsWith(".gif")
+  && !path.endsWith(".jpg")
+  && !path.endsWith(".png")
+  && !path.endsWith(".css");
+ 
+ // If filtering is not applied or the deny list conditions are met, proceed to check content type
+ if (configNoFilter || filterDenyList) {
+     // verify that the request is a POST, PUT, or PATCH and that the response is json
+     if (!requestResponse.hasResponse() || request.method().equals("POST") || request.method().equals("PATCH") || request.method().equals("PUT")) {
+         var contentType = response.headerValue("Content-Type");
+         // verify the content-type is json
+         if (contentType != null && contentType.contains("application/json")) {
+             return true;
+         }
+     }
+ }
+ 
+ return false; // Ensure method returns a boolean in all cases

--- a/Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda
+++ b/Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda
@@ -1,0 +1,33 @@
+/**
+ * Filters non-empty 200 response classes 
+ * 
+ * // Use `cat your-oas-api-spec-doc.json | jq -r '.components.schemas.[].properties? | keys? | .[]' | sort -u > json-wordlist.txt` to create a wordlist prior to attacking endpoints with paramminer
+ * 
+ * @author GangGreenTemperTatum (https://github.com/GangGreenTemperTatum)
+ **/
+
+var configNoFilter = false;        // if set to false, won't show JS, GIF, JPG, PNG, CSS.
+var configInScopeOnly = true;      // if set to true, won't show out-of-scope items
+var request = requestResponse.request(); // create a var for request
+var response = requestResponse.response(); // create a var for response
+
+if (configInScopeOnly && !request.isInScope()) {
+    return false;
+}
+
+if (response == null || !response.isStatusCodeClass(StatusCodeClass.CLASS_2XX_SUCCESS)) {
+    return false; // return only status codes of 2xx
+}
+
+// verify that the request is a POST, PUT, or PATCH
+if (!requestResponse.hasResponse() || request.method().equals("POST") || request.method().equals("PATCH") || request.method().equals("PUT")) {
+    // verify that the response is json
+    var contentType = response.headerValue("Content-Type");
+
+    // verify the content-type is json
+    if (contentType != null && contentType.contains("application/json")) {
+        return true;
+    }
+}
+
+return false; // This line ensures the method returns a boolean value

--- a/Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda
+++ b/Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda
@@ -42,7 +42,7 @@ var response = requestResponse.response();
  // If filtering is not applied or the deny list conditions are met, proceed to check content type
  if (configNoFilter || filterDenyList) {
      // verify that the request is a POST, PUT, or PATCH and that the response is json
-     if (!requestResponse.hasResponse() || request.method().equals("POST") || request.method().equals("PATCH") || request.method().equals("PUT")) {
+     if (request.method().equals("POST") || request.method().equals("PATCH") || request.method().equals("PUT")) {
          var contentType = response.headerValue("Content-Type");
          // verify the content-type is json
          if (contentType != null && contentType.contains("application/json")) {

--- a/Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda
+++ b/Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda
@@ -1,7 +1,7 @@
 /**
- * Filters non-empty 200 response classes 
+ * Filters non-empty 200 json-based response classes which can be used to find easy routes to attack with the paramminer guess json params and a custom wordlist, ie:
  * 
- * // Use `cat your-oas-api-spec-doc.json | jq -r '.components.schemas.[].properties? | keys? | .[]' | sort -u > json-wordlist.txt` to create a wordlist prior to attacking endpoints with paramminer
+ // $ cat your-oas-api-spec-doc.json | jq -r '.components.schemas.[].properties? | keys? | .[]' | sort -u > json-wordlist.txt 
  * 
  * @author GangGreenTemperTatum (https://github.com/GangGreenTemperTatum)
  **/


### PR DESCRIPTION
### Bambda Contributions

idea is to use this as a bambda, following creation of a custom wordlist from generating/extracting JSON params from an OAPI spec for you to easily identify the `200`'s which you want to throw the wordlist at (IE `extensions > paramminer > guess JSON > custom wordlist` etc.)

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [x] Bambda compiles and executes as expected
* [x] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)

```shell
➜  bambdas-fork git:(ads/createbambdaforparamminer) ✗ java -jar BambdaChecker-1.3.jar validateonly ./Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda
...
Bambda ./Filter/Proxy/HTTP/HighlightParamMinerTargets.bambda parsed correct.
```