### PR TITLE
Create Detect403Forbidden.bambda

### DIFF
--- a/Filter/Proxy/HTTP/Detect403Forbidden.bambda
+++ b/Filter/Proxy/HTTP/Detect403Forbidden.bambda
@@ -1,0 +1,9 @@
+/**
+ * Bambda Script to Detect "403 Forbidden" in HTTP Response
+ * @author ctflearner
+ * This script identifies if the HTTP response status code is 403 (Forbidden).
+ * It ensures there is a response and checks if the status code indicates access is denied.
+ **/
+
+
+return requestResponse.hasResponse() && requestResponse.response().statusCode() == 403;


### PR DESCRIPTION
This script identifies if the HTTP response status code is 403 (Forbidden).

### Bambda Contributions

* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [ ] Bambda compiles and executes as expected
* [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
