### PR TITLE
Create DetectWeakReferrerPolicy.bambda

### DIFF
--- a/Filter/Proxy/HTTP/DetectWeakReferrerPolicy.bambda
+++ b/Filter/Proxy/HTTP/DetectWeakReferrerPolicy.bambda
@@ -8,17 +8,26 @@
  **/
 
 
-return requestResponse.hasResponse() && (
-    // No Referrer-Policy header
-    requestResponse.response().headers().stream()
-        .noneMatch(header -> header.name().equalsIgnoreCase("Referrer-Policy")) ||
-    
-    // Check for potentially weak referrer policies
-    requestResponse.response().headers().stream()
-        .filter(header -> header.name().equalsIgnoreCase("Referrer-Policy"))
-        .anyMatch(header -> {
-            String value = header.value().toLowerCase().trim();
-            return value.equals("no-referrer-when-downgrade") ||
-                   value.equals("unsafe-url");
-        })
+if (!requestResponse.hasResponse()) {
+    return false;
+}
+
+Optional<HttpHeader> referrerPolicyHeader = Optional.ofNullable(
+    requestResponse.response().header("Referrer-Policy")
 );
+
+if (referrerPolicyHeader.isEmpty()) {
+    return true;
+}
+
+String headerValue = referrerPolicyHeader.get().value().toLowerCase(Locale.US).trim();
+
+// Check for weak referrer policies using a stream
+boolean hasWeakPolicy = requestResponse.response().headers().stream()
+    .filter(header -> header.name().equalsIgnoreCase("Referrer-Policy"))
+    .anyMatch(header -> {
+        String value = header.value().toLowerCase(Locale.US).trim(); // Include Locale for toLowerCase()
+        return value.equals("no-referrer-when-downgrade") || value.equals("unsafe-url");
+    });
+
+return headerValue.equals("no-referrer-when-downgrade") || headerValue.equals("unsafe-url") || hasWeakPolicy;

--- a/Filter/Proxy/HTTP/DetectWeakReferrerPolicy.bambda
+++ b/Filter/Proxy/HTTP/DetectWeakReferrerPolicy.bambda
@@ -1,0 +1,24 @@
+/**
+ * Bambda Script to Detect "Weak or Missing Referrer-Policy" Header in HTTP Response
+ * @author ctflearner
+ * This script checks if the HTTP response lacks the "Referrer-Policy" header or uses a weak policy, 
+ * such as "no-referrer-when-downgrade" or "unsafe-url". 
+ * It ensures there is a response and scans the headers for either the absence of the Referrer-Policy header 
+ * or the presence of policies that may expose sensitive referrer information.
+ **/
+
+
+return requestResponse.hasResponse() && (
+    // No Referrer-Policy header
+    requestResponse.response().headers().stream()
+        .noneMatch(header -> header.name().equalsIgnoreCase("Referrer-Policy")) ||
+    
+    // Check for potentially weak referrer policies
+    requestResponse.response().headers().stream()
+        .filter(header -> header.name().equalsIgnoreCase("Referrer-Policy"))
+        .anyMatch(header -> {
+            String value = header.value().toLowerCase().trim();
+            return value.equals("no-referrer-when-downgrade") ||
+                   value.equals("unsafe-url");
+        })
+);


### PR DESCRIPTION
It ensures there is a response and scans the headers for either the absence of the Referrer-Policy header or the presence of policies that may expose sensitive referrer information.

### Bambda Contributions

* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [ ] Bambda compiles and executes as expected
* [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
