### PR TITLE
Create DetectCSPReportOnlyHeader.bambda

### DIFF
--- a/Filter/Proxy/HTTP/DetectCSPReportOnlyHeader.bambda
+++ b/Filter/Proxy/HTTP/DetectCSPReportOnlyHeader.bambda
@@ -1,0 +1,25 @@
+/**
+ * Bambda Script to Detect "Content-Security-Policy-Report-Only (CSP-RO)" Header in HTTP Response
+ * @author ctflearner
+ * This script checks if the HTTP response contains the "Content-Security-Policy-Report-Only" header, 
+ * which is used for monitoring CSP violations without enforcing restrictions. 
+ * Additionally, it verifies if the header specifies a "report-uri" directive, 
+ * indicating where CSP violation reports are sent.
+ * The script ensures there is a response and scans the headers for these conditions.
+ **/
+
+
+
+return requestResponse.hasResponse() && (
+    // Check for Content-Security-Policy-Report-Only header
+    requestResponse.response().headers().stream()
+        .anyMatch(header -> 
+            header.name().equalsIgnoreCase("Content-Security-Policy-Report-Only")
+        ) &&
+    // Optional: Check if report-uri is specified
+    requestResponse.response().headers().stream()
+        .anyMatch(header -> 
+            header.name().equalsIgnoreCase("Content-Security-Policy-Report-Only") && 
+            header.value().toLowerCase().contains("report-uri")
+        )
+);


### PR DESCRIPTION
This script checks if the HTTP response contains the "Content-Security-Policy-Report-Only" header, which is used for monitoring CSP violations without enforcing restrictions.

### Bambda Contributions

* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [ ] Bambda compiles and executes as expected
* [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
