### PR TITLE
add RepeaterClip Bambdas

### DIFF
--- a/CustomAction/RepeaterClipNewFromClipboard.bambda
+++ b/CustomAction/RepeaterClipNewFromClipboard.bambda
@@ -1,0 +1,47 @@
+id: 8e740b42-3e7a-45c5-9a92-8b18b494bc92
+name: RepeaterClip: New from Clipboard
+function: CUSTOM_ACTION
+location: REPEATER
+source: |+
+  /**
+   * Given the clipboard contains a repeater request compressed and encoded by the RepeaterClip Bambda,
+   * this Bambda creates a new Repeater tab containing that request.
+   *
+   * @author 0xd0ug (https://github.com/0xd0ug)
+   **/
+   
+  try {
+      String clipboardContent = (String) java.awt.Toolkit.getDefaultToolkit().getSystemClipboard().getData(java.awt.datatransfer.DataFlavor.stringFlavor);
+      
+      if (clipboardContent == null || !clipboardContent.startsWith("REPEATERCLIP/")) {
+          logging.logToError("Invalid clipboard content. Expected format: REPEATERCLIP/protocol/host/port/base64data");
+          return;
+      }
+      
+      String[] parts = clipboardContent.split("/", 5);
+      if (parts.length != 5) {
+          logging.logToError("Invalid clipboard format. Expected 5 parts separated by '/'");
+          return;
+      }
+      
+      String protocol = parts[1];
+      String host = parts[2];
+      int port = Integer.parseInt(parts[3]);
+      String base64Data = parts[4];
+      
+      var decodedData = api.utilities().base64Utils().decode(burp.api.montoya.core.ByteArray.byteArray(base64Data));
+      var decompressedRequest = api.utilities().compressionUtils().decompress(decodedData, burp.api.montoya.utilities.CompressionType.GZIP);
+      
+      boolean isSecure = "https".equals(protocol);
+      var httpService = burp.api.montoya.http.HttpService.httpService(host, port, isSecure);
+      var restoredRequest = burp.api.montoya.http.message.requests.HttpRequest.httpRequest(httpService, decompressedRequest);
+      
+      api.repeater().sendToRepeater(restoredRequest);
+      
+      logging.logToOutput("Successfully restored request from clipboard and sent to new Repeater tab");
+      logging.logToOutput("Protocol: " + protocol + ", Host: " + host + ", Port: " + port);
+      
+  } catch (Exception e) {
+      logging.logToError("Error restoring request from clipboard: " + e.getMessage());
+      e.printStackTrace();
+  }

--- a/CustomAction/RepeaterClipShareToClipboard.bambda
+++ b/CustomAction/RepeaterClipShareToClipboard.bambda
@@ -1,0 +1,40 @@
+id: 361c963f-346e-427b-a93e-86db21d11a73
+name: RepeaterClip: Share to Clipboard
+function: CUSTOM_ACTION
+location: REPEATER
+source: |+
+  /**
+   * Compresses and encodes the current repeater request, copying the result to the clipboard.
+   *
+   * @author 0xd0ug (https://github.com/0xd0ug)
+   **/
+  
+  try {
+      var httpService = requestResponse.httpService();
+      String protocol = httpService.secure() ? "https" : "http";
+      String host = httpService.host();
+      int port = httpService.port();
+      
+      var requestByteArray = requestResponse.request().toByteArray();
+      
+      var compressedRequest = api.utilities().compressionUtils().compress(requestByteArray, burp.api.montoya.utilities.CompressionType.GZIP);
+      
+      String base64EncodedRequest = api.utilities().base64Utils().encodeToString(compressedRequest);
+      
+      String result = "REPEATERCLIP/" + protocol + "/" + host + "/" + port + "/" + base64EncodedRequest;
+      
+      java.awt.Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new java.awt.datatransfer.StringSelection(result), null);
+      
+      logging.logToOutput("Successfully copied request data to clipboard");
+      logging.logToOutput("Format: " + protocol + "/" + host + "/" + port + "/[base64-encoded-compressed-request]");
+      
+  } catch (Exception e) {
+      try {
+          java.awt.Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new java.awt.datatransfer.StringSelection(""), null);
+      } catch (Exception clipboardError) {
+          logging.logToError("Failed to clear clipboard: " + clipboardError.getMessage());
+      }
+      
+      logging.logToError("Error processing request: " + e.getMessage());
+      e.printStackTrace();
+  }


### PR DESCRIPTION
### Bambda Contributions

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [x] Bambda compiles and executes as expected
* [x] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
* [x] Bambda is in valid yaml format, and has a name, id, function, and location. To ensure this is correct, export the Bambda from your Bambda library in Burp.

This Bambda replaces the [ClipboardRepeater Extension](https://portswigger.net/bappstore/3acc902eddde49aa83be2c71121ece88) I wrote awhile back. The new Custom Actions framework makes this much easier to use. A user can click the "Share" action, and the request is compressed, encoded, and then copied to the clipboard. This is so requests can be sent through any instant messaging client for collaboration, even if they contain unusual characters, and even if the host header differs from the target host (useful in checking for firewall bypasses). The receiving user can copy the blob to their clipboard and then click the "New" action to create a new Repeater tab with the original request.