### PR TITLE
Hash Highlight Bambda

### DIFF
--- a/Filter/Proxy/HTTP/HighlightHashes.bambda
+++ b/Filter/Proxy/HTTP/HighlightHashes.bambda
@@ -3,6 +3,12 @@ name: Highlight Hashes
 function: VIEW_FILTER
 location: PROXY_HTTP_HISTORY
 source: |+
+ /**
+   * This script highlights and annotates the proxy history if any responses contain a common password hash variant.
+   *
+   * @author Daniel Roberts (https://github.com/DannyCymru)
+   *
+   **/
   if (!requestResponse.hasResponse()){
   	return false;
   }

--- a/Filter/Proxy/HTTP/HighlightHashes.bambda
+++ b/Filter/Proxy/HTTP/HighlightHashes.bambda
@@ -6,7 +6,7 @@ source: |+
  /**
    * This script highlights and annotates the proxy history if any responses contain a common password hash variant.
    *
-   * @author Daniel Roberts (https://github.com/DannyCymru)
+   * @author Daniel Roberts (https://github.com/ErebusC)
    *
    **/
   if (!requestResponse.hasResponse()){

--- a/Filter/Proxy/HTTP/HighlightHashes.bambda
+++ b/Filter/Proxy/HTTP/HighlightHashes.bambda
@@ -9,38 +9,48 @@ source: |+
    * @author Daniel Roberts (https://github.com/ErebusC)
    *
    **/
-  if (!requestResponse.hasResponse()){
-  	return false;
-  }
-  
-  var response_body = requestResponse.response().bodyToString();
-  
-  boolean manualColorHighlightEnabled = true;
-  boolean found_hash = false;
+if (!requestResponse.hasResponse()){return false;
+}
 
-  // Regex for all common password hashes one may find during a web application test  
-  String regex ="['\"]?\\s*(?:\\$argon2(id|i|d)?\\$v=\\d+\\$[a-z0-9=,]+\\$[A-Za-z0-9+/=]+\\$[A-Za-z0-9+/=]+|\\$2[abxyz]?\\$\\d{1,2}\\$[./A-Za-z0-9]{53,}|pbkdf2_[a-z0-9]+\\$\\d+\\$[A-Za-z0-9+/=]+\\$[A-Za-z0-9+/=]+|\\$(1|5|6)\\$[./A-Za-z0-9]{1,16}\\$[./A-Za-z0-9]{22,}|\\$P\\$[./A-Za-z0-9]{31}|[a-fA-F0-9]{128}|[a-fA-F0-9]{96}|[a-fA-F0-9]{64}|[a-fA-F0-9]{40}|[a-fA-F0-9]{32})\\s*['\"]?";
-  
-  Pattern hash_patterns = Pattern.compile(regex);
-  
-  Matcher hash_matcher = hash_patterns.matcher(response_body);
-  
-  var annotate = requestResponse.annotations();
-  String hashes = "Potential hash identified: ";
-  
-  while(hash_matcher.find()){
-      found_hash = true;
-      hashes += hash_matcher.group()+"";
-  }
-  
-  if (found_hash){
-      annotate.setHighlightColor(HighlightColor.BLUE);
-      
-      if(!annotate.hasNotes()){
-      	annotate.setNotes(hashes);
-      }
-      else if(annotate.hasNotes() && !annotate.notes().contains(hashes)){
-          annotate.setNotes(annotate.notes() + hashes);
-      }
-  }
-  return true;
+var response_body = requestResponse.response().bodyToString();
+
+boolean manualColorHighlightEnabled = true;
+boolean found_hash = false;
+
+// Regex for all common password hashes one may find during a web application test  
+String regex = "['\"]?\\s*(?:"
+    + "\\$argon2(?:id|i|d)?\\$v=\\d+\\$m=\\d+,t=\\d+,p=\\d+\\$[A-Za-z0-9+/=]+\\$[A-Za-z0-9+/=]+"
+    + "|\\$2[abxyz]?\\$\\d{1,2}\\$[./A-Za-z0-9]{53}"
+    + "|(?i)pbkdf2_[a-z0-9]+\\$\\d+\\$[A-Za-z0-9+/=]+\\$[A-Za-z0-9+/=]+"
+    + "|\\$(1|5|6)\\$[./A-Za-z0-9]{1,16}\\$[./A-Za-z0-9]{22,}"
+    + "|\\$P\\$[./A-Za-z0-9]{31}"
+    + "|\\b[a-fA-F0-9]{128}\\b"
+    + "|\\b[a-fA-F0-9]{96}\\b"
+    + "|\\b[a-fA-F0-9]{64}\\b"
+    + "|\\b[a-fA-F0-9]{40}\\b"
+    + "|\\b[a-fA-F0-9]{32}\\b"
+    + ")\\s*['\"]?";
+
+Pattern hash_patterns = Pattern.compile(regex);
+
+Matcher hash_matcher = hash_patterns.matcher(response_body);
+
+var annotate = requestResponse.annotations();
+String hashes = "Potential hash identified: ";
+
+while(hash_matcher.find()){
+    found_hash = true;
+    hashes += hash_matcher.group()+"\n";
+}
+
+if (found_hash){
+    annotate.setHighlightColor(HighlightColor.BLUE);
+
+    if(!annotate.hasNotes()){
+    annotate.setNotes(hashes);
+    }
+    else if(annotate.hasNotes() && !annotate.notes().contains(hashes)){
+        annotate.setNotes(annotate.notes() + hashes);
+    }
+}
+return true;

--- a/Filter/Proxy/HTTP/HighlightHashes.bambda
+++ b/Filter/Proxy/HTTP/HighlightHashes.bambda
@@ -1,0 +1,40 @@
+id: e4e63bf1-e3bf-46e3-9781-5a45d45bf80a
+name: Highlight Hashes
+function: VIEW_FILTER
+location: PROXY_HTTP_HISTORY
+source: |+
+  if (!requestResponse.hasResponse()){
+  	return false;
+  }
+  
+  var response_body = requestResponse.response().bodyToString();
+  
+  boolean manualColorHighlightEnabled = true;
+  boolean found_hash = false;
+
+  // Regex for all common password hashes one may find during a web application test  
+  String regex ="['\"]?\\s*(?:\\$argon2(id|i|d)?\\$v=\\d+\\$[a-z0-9=,]+\\$[A-Za-z0-9+/=]+\\$[A-Za-z0-9+/=]+|\\$2[abxyz]?\\$\\d{1,2}\\$[./A-Za-z0-9]{53,}|pbkdf2_[a-z0-9]+\\$\\d+\\$[A-Za-z0-9+/=]+\\$[A-Za-z0-9+/=]+|\\$(1|5|6)\\$[./A-Za-z0-9]{1,16}\\$[./A-Za-z0-9]{22,}|\\$P\\$[./A-Za-z0-9]{31}|[a-fA-F0-9]{128}|[a-fA-F0-9]{96}|[a-fA-F0-9]{64}|[a-fA-F0-9]{40}|[a-fA-F0-9]{32})\\s*['\"]?";
+  
+  Pattern hash_patterns = Pattern.compile(regex);
+  
+  Matcher hash_matcher = hash_patterns.matcher(response_body);
+  
+  var annotate = requestResponse.annotations();
+  String hashes = "Potential hash identified: ";
+  
+  while(hash_matcher.find()){
+      found_hash = true;
+      hashes += hash_matcher.group()+"";
+  }
+  
+  if (found_hash){
+      annotate.setHighlightColor(HighlightColor.BLUE);
+      
+      if(!annotate.hasNotes()){
+      	annotate.setNotes(hashes);
+      }
+      else if(annotate.hasNotes() && !annotate.notes().contains(hashes)){
+          annotate.setNotes(annotate.notes() + hashes);
+      }
+  }
+  return true;

--- a/Filter/Proxy/HTTP/HighlightHashes.bambda
+++ b/Filter/Proxy/HTTP/HighlightHashes.bambda
@@ -1,56 +1,57 @@
-id: e4e63bf1-e3bf-46e3-9781-5a45d45bf80a
-name: Highlight Hashes
+id: 4cc735ed-d214-470c-91d3-f7711db31efd
+name: HighlightHashes
 function: VIEW_FILTER
 location: PROXY_HTTP_HISTORY
 source: |+
- /**
-   * This script highlights and annotates the proxy history if any responses contain a common password hash variant.
-   *
-   * @author Daniel Roberts (https://github.com/ErebusC)
-   *
-   **/
-if (!requestResponse.hasResponse()){return false;
-}
-
-var response_body = requestResponse.response().bodyToString();
-
-boolean manualColorHighlightEnabled = true;
-boolean found_hash = false;
-
-// Regex for all common password hashes one may find during a web application test  
-String regex = "['\"]?\\s*(?:"
-    + "\\$argon2(?:id|i|d)?\\$v=\\d+\\$m=\\d+,t=\\d+,p=\\d+\\$[A-Za-z0-9+/=]+\\$[A-Za-z0-9+/=]+"
-    + "|\\$2[abxyz]?\\$\\d{1,2}\\$[./A-Za-z0-9]{53}"
-    + "|(?i)pbkdf2_[a-z0-9]+\\$\\d+\\$[A-Za-z0-9+/=]+\\$[A-Za-z0-9+/=]+"
-    + "|\\$(1|5|6)\\$[./A-Za-z0-9]{1,16}\\$[./A-Za-z0-9]{22,}"
-    + "|\\$P\\$[./A-Za-z0-9]{31}"
-    + "|\\b[a-fA-F0-9]{128}\\b"
-    + "|\\b[a-fA-F0-9]{96}\\b"
-    + "|\\b[a-fA-F0-9]{64}\\b"
-    + "|\\b[a-fA-F0-9]{40}\\b"
-    + "|\\b[a-fA-F0-9]{32}\\b"
-    + ")\\s*['\"]?";
-
-Pattern hash_patterns = Pattern.compile(regex);
-
-Matcher hash_matcher = hash_patterns.matcher(response_body);
-
-var annotate = requestResponse.annotations();
-String hashes = "Potential hash identified: ";
-
-while(hash_matcher.find()){
-    found_hash = true;
-    hashes += hash_matcher.group()+"\n";
-}
-
-if (found_hash){
-    annotate.setHighlightColor(HighlightColor.BLUE);
-
-    if(!annotate.hasNotes()){
-    annotate.setNotes(hashes);
-    }
-    else if(annotate.hasNotes() && !annotate.notes().contains(hashes)){
-        annotate.setNotes(annotate.notes() + hashes);
-    }
-}
-return true;
+  /**
+  * This script highlights and annotates the proxy history if any responses contain a common password hash variant.
+  *
+  * @author Daniel Roberts (https://github.com/ErebusC)
+  *
+  **/
+  if (!requestResponse.hasResponse()){
+  	return false;
+  }
+  
+  var response_body = requestResponse.response().bodyToString();
+  
+  boolean manualColorHighlightEnabled = true;
+  boolean found_hash = false;
+  
+  // Regex for all common password hashes one may find during a web application test  
+  String regex = "['\"]?\\s*(?:"
+      + "\\$argon2(?:id|i|d)?\\$v=\\d+\\$m=\\d+,t=\\d+,p=\\d+\\$[A-Za-z0-9+/=]+\\$[A-Za-z0-9+/=]+"
+      + "|\\$2[abxyz]?\\$\\d{1,2}\\$[./A-Za-z0-9]{53}"
+      + "|(?i)pbkdf2_[a-z0-9]+\\$\\d+\\$[A-Za-z0-9+/=]+\\$[A-Za-z0-9+/=]+"
+      + "|\\$(1|5|6)\\$[./A-Za-z0-9]{1,16}\\$[./A-Za-z0-9]{22,}"
+      + "|\\$P\\$[./A-Za-z0-9]{31}"
+      + "|\\b[a-fA-F0-9]{128}\\b"
+      + "|\\b[a-fA-F0-9]{96}\\b"
+      + "|\\b[a-fA-F0-9]{64}\\b"
+      + "|\\b[a-fA-F0-9]{40}\\b"
+      + "|\\b[a-fA-F0-9]{32}\\b"
+      + ")\\s*['\"]?";
+  
+  Pattern hash_patterns = Pattern.compile(regex);
+  
+  Matcher hash_matcher = hash_patterns.matcher(response_body);
+  
+  var annotate = requestResponse.annotations();
+  String hashes = "Potential hash identified: ";
+  
+  while(hash_matcher.find()){
+      found_hash = true;
+      hashes += hash_matcher.group()+"\n";
+  }
+  
+  if (found_hash){
+      annotate.setHighlightColor(HighlightColor.BLUE);
+  
+      if(!annotate.hasNotes()){
+      	annotate.setNotes(hashes);
+      }
+      else if(annotate.hasNotes() && !annotate.notes().contains(hashes)){
+          annotate.setNotes(annotate.notes() + hashes);
+      }
+  }
+  return true;


### PR DESCRIPTION
Created a bambda that highlights and annotates the proxy history if a password hash is identified. This covers all variants of common password hashes.

### Bambda Contributions

* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [ ] Bambda compiles and executes as expected
* [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
* [ ] Bambda is in valid yaml format, and has a name, id, function, and location. To ensure this is correct, export the Bambda from your Bambda library in Burp.
