### PR TITLE
This adds AI Hacking Assistant Bambda.

### DIFF
--- a/CustomAction/HackingAssistant.bambda
+++ b/CustomAction/HackingAssistant.bambda
@@ -1,0 +1,57 @@
+id: c6d8f960-fe3d-436f-acd6-f6a447fe4c17
+name: Hacking assistant
+function: CUSTOM_ACTION
+location: REPEATER
+source: |+
+/**
+  * Creates an AI assistant that can modify the HTTP request with instructions given in the prompt supplied by the user.
+  * Example instructions are "Exploit this XSS" or "URL encode this"
+  * @author Gareth Heyes
+  **/
+  var selectedText = (selection.hasRequestSelection() ? selection.requestSelection() : selection.responseSelection()).contents().toString();
+  
+  var userPrompt = javax.swing.JOptionPane.showInputDialog(null, "Enter a AI prompt to run on the selection", "AI Prompt", javax.swing.JOptionPane.QUESTION_MESSAGE);
+  
+  if(userPrompt == null) return;
+  
+  var systemPrompt = """
+  You are an assistant inside Burp Suite's Repeater. 
+  The user is going to give you a LLM prompt and some selected input, a HTTP request and response as a JSON object. 
+  You should do what the user requests and bear in mind it's used for web security research.
+  You should always return your response as a JSON object. Do not output markdown. Your response should always start with "{".
+  Your response should always end with "}".
+  If the user asks you to modify request you can return a property called modified request where you should place the modified request.
+  The description field should contain a short description of what you've done.
+  The JSON object should always be returned like this:
+  {
+    "modifiedRequest": string
+    "description": string
+  }
+  """;
+  
+  var jsonInput = JsonObjectNode.jsonObjectNode();
+  jsonInput.putString("Selected text", selectedText);
+  jsonInput.putString("Request", requestResponse.request().toString());
+  jsonInput.putString("Response", requestResponse.response().toString());
+  
+  var aiResponse = api.ai().prompt().execute(PromptOptions.promptOptions().withTemperature(1.0), 
+  Message.systemMessage(systemPrompt), Message.userMessage(userPrompt + "\n\n" + jsonInput.toJsonString())
+  ).content();
+  
+  aiResponse = aiResponse.replaceFirst("^\\s*```json","");
+  aiResponse = aiResponse.replaceFirst("\\s*```$","");
+  
+  if(!api.utilities().jsonUtils().isValidJson(aiResponse)) {
+     logging().logToError("The AI returned invalid json:" + aiResponse);
+     return;
+  }
+  
+  var modifiedRequest = api().utilities().jsonUtils().readString(aiResponse, "modifiedRequest");
+  var description = api().utilities().jsonUtils().readString(aiResponse, "description");
+  
+  if(modifiedRequest != null) {
+      httpEditor.requestPane().set(modifiedRequest);
+  }
+  
+  api.logging().logToOutput(description);
+  


### PR DESCRIPTION
This PR adds a AI hacking assistant to Burp AI custom actions in Repeater. It works by asking the user for a prompt using Swing's input dialog. This allows the user to write prompts like "Exploit this XSS" or "URL encode this". I gave the AI the ability to modify the request which means the instructions can easily change the request to reflect the instructions. This is just the tip of the iceberg, you could write hacking assistants for all sorts of web security tasks.

**Note** This requires access to `httpEditor.requestPane()` which is only available on 2025-6-3 or later versions of Burp.