### PR TITLE
Add action to test support for HTTP TRACE.

### DIFF
--- a/CustomAction/TestHTTPTRACESupport.bambda
+++ b/CustomAction/TestHTTPTRACESupport.bambda
@@ -1,0 +1,13 @@
+id: 5380ba12-ed58-4c05-8646-54e850b6536b
+name: Test HTTP TRACE support
+function: CUSTOM_ACTION
+location: REPEATER
+source: |+
+  /**
+  * Test support for HTTP Trace method.
+  *
+  * @author righettod (https://github.com/righettod)
+  **/
+  var req = requestResponse.request();
+  var httpCode = api().http().sendRequest(req.withMethod("TRACE")).response().statusCode();
+  logging().logToOutput("HTTP " + httpCode + " returned.");


### PR DESCRIPTION
# Bambda Contributions

Hi,

This PR propose a action to test if the current request support HTTP TRACE.

I tested it against the last version of Burp pro edition:

<img width="1186" height="577" alt="image" src="https://github.com/user-attachments/assets/ea5f68c0-af9c-4fb0-8a71-4583126dc15a" />

Thank you very much for your feedback 😃 

# Checks

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [x] Bambda compiles and executes as expected
* [x] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
* [x] Bambda is in valid yaml format, and has a name, id, function, and location. To ensure this is correct, export the Bambda from your Bambda library in Burp.
