### PR TITLE
Websocket-aes-decrypt

### DIFF
--- a/CustomAction/Websocket-aes-decrypt.bambda
+++ b/CustomAction/Websocket-aes-decrypt.bambda
@@ -1,0 +1,35 @@
+id: 912e3faa-2b15-49b7-93bb-5dee4eefd94d
+name: websocket-aes-decrypt
+function: VIEW_FILTER
+location: PROXY_WEBSOCKET
+source: |+
+  /**
+  Script created to decrypt AES encrypted websocket message. The script decrypt websocket message and log the plaintext as notes.
+  
+  @author https://github.com/m0dslacker/websocket-aes-decrypt
+  **/
+  
+  try {
+      String KEY = "AESKEY"; //Change key
+      String ALGORITHM = "AES";
+      String TRANSFORMATION = "AES/ECB/PKCS5Padding";
+      
+  	javax.crypto.spec.SecretKeySpec keySpec = new javax.crypto.spec.SecretKeySpec(KEY.getBytes(), ALGORITHM);
+      javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance(TRANSFORMATION);
+      cipher.init(javax.crypto.Cipher.DECRYPT_MODE, keySpec);
+      //logging().logToOutput("[DEBUG] To decrypt : " + message.payload().toString());
+  	ByteArray encrypted  = utilities().base64Utils().decode(message.payload());
+      byte [] decrypted = cipher.doFinal(encrypted.getBytes());
+      String plaintext = new String(decrypted);
+      message.annotations().setNotes(plaintext);
+      //logging().logToOutput("[DEBUG] Attempting to decrypt");
+      //logging().logToOutput("[DEBUG] Plaintext : "  + plaintext);
+  }
+  catch (Exception e){
+      logging().logToError("[ERROR] Unable to decrypt");
+  }
+  finally {
+  	logging().logToOutput("[INFO] Attempted decrypt");
+  }
+  
+  return true;


### PR DESCRIPTION
This bambda can be used to perform AES decrypt on encrypted websocket message. Plaintext is posted to notes.

### Bambda Contributions

* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [ ] Bambda compiles and executes as expected
* [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
* [ ] Bambda is in valid yaml format, and has a name, id, function, and location. To ensure this is correct, export the Bambda from your Bambda library in Burp.
