### PR TITLE
Update blogpost URL in SmugglingOrPipelining.bambda to fix 404

### DIFF
--- a/CustomAction/SmugglingOrPipelining.bambda
+++ b/CustomAction/SmugglingOrPipelining.bambda
@@ -28,7 +28,7 @@ source: |+
   } else {
        logging().logToOutput("Looks like smuggling");
   }
-  logging().logToOutput("For further information, refer to https://portswigger.net/research/smuggling-or-pipelining");
+  logging().logToOutput("For further information, refer to https://portswigger.net/research/how-to-distinguish-http-pipelining-from-request-smuggling");
   
 
 


### PR DESCRIPTION
Changed the URL in the Bambda to what I assume is now the correct URL: https://portswigger.net/research/how-to-distinguish-http-pipelining-from-request-smuggling