### PR TITLE
Add CORS misconfiguration Bambda.

### DIFF
--- a/CustomScanChecks/CORSMisconfiguration.bambda
+++ b/CustomScanChecks/CORSMisconfiguration.bambda
@@ -13,8 +13,8 @@ source: |
       return null;
   }
 
-  var evilHttps = "https://" + api().utilities().randomUtils().randomString(6) + ".evil.test";
-  var evilHttp = "http://" + api().utilities().randomUtils().randomString(6) + ".evil.test";
+  var evilHttps = "https://" + api().utilities().randomUtils().randomString(6) + "." + api().utilities().randomUtils().randomString(3);
+  var evilHttp = "http://" + api().utilities().randomUtils().randomString(6) + "." + api().utilities().randomUtils().randomString(3);
 
   for (var origin : new String[]{evilHttps, evilHttp})
   {

--- a/CustomScanChecks/CORSMisconfiguration.bambda
+++ b/CustomScanChecks/CORSMisconfiguration.bambda
@@ -1,0 +1,53 @@
+id: 46cae4a9-45ff-406a-80bc-c9a0fe630535
+name: CORS misconfiguration
+function: SCAN_CHECK_ACTIVE_PER_REQUEST
+location: SCANNER
+source: |
+  /**
+   * Identifies CORS misconfiguration.
+   * @author PortSwigger
+   **/
+
+  if (!requestResponse.hasResponse())
+  {
+      return null;
+  }
+
+  var evilHttps = "https://" + api().utilities().randomUtils().randomString(6) + ".evil.test";
+  var evilHttp = "http://" + api().utilities().randomUtils().randomString(6) + ".evil.test";
+
+  for (var origin : new String[]{evilHttps, evilHttp})
+  {
+      var rr = http.sendRequest(requestResponse.request().withAddedHeader("Origin", origin));
+      if (!rr.hasResponse())
+      {
+          continue;
+      }
+
+      var headers = rr.response().headers().toString().toLowerCase();
+      var creds = headers.contains("access-control-allow-credentials: true");
+      var reflect = headers.contains("access-control-allow-origin: " + origin.toLowerCase());
+      var vary = headers.contains("vary: origin");
+
+      if (reflect)
+      {
+          var severity = creds ? AuditIssueSeverity.HIGH : AuditIssueSeverity.MEDIUM;
+          var note = vary ? "" : " (missing Vary: Origin)";
+          return AuditResult.auditResult(
+                  AuditIssue.auditIssue(
+                          "CORS: arbitrary origin reflection" + note,
+                          "Reflected Origin: " + origin + "; credentials=" + creds,
+                          "Use strict allowlist; include Vary: Origin.",
+                          rr.request().url(),
+                          severity,
+                          AuditIssueConfidence.FIRM,
+                          "",
+                          "",
+                          severity,
+                          rr
+                  )
+          );
+      }
+  }
+
+  return AuditResult.auditResult();


### PR DESCRIPTION
Add Bambda to identify CORS misconfiguration.

### Bambda Contributions

* [x] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [x] Bambda compiles and executes as expected
* [x] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
* [x] Bambda is in valid yaml format, and has a name, id, function, and location. To ensure this is correct, export the Bambda from your Bambda library in Burp.
