### PR TITLE
Add SSTI sampler Bambda.

### DIFF
--- a/CustomScanChecks/SSTISampler.bambda
+++ b/CustomScanChecks/SSTISampler.bambda
@@ -1,0 +1,53 @@
+id: 4ab9589a-0da5-4310-920d-bce6066ad1f6
+name: SSTI sampler
+function: SCAN_CHECK_ACTIVE_PER_INSERTION_POINT
+location: SCANNER
+source: |
+  /**
+   * Identifies server-side template injection.
+   * @author PortSwigger
+   **/
+
+  if (insertionPoint == null)
+  {
+      return AuditResult.auditResult();
+  }
+
+  record Probe(String name, String[] payloads, String expectRegex) {}
+
+  var probes = List.of(
+          new Probe("Jinja/Twig", new String[]{"{{7*7}}", "}} {{7*7}} {{", "#{7*7}#"}, "\\b49\\b"),
+          new Probe("Velocity/Thymeleaf/Freemarker", new String[]{"${7*7}", "}}${7*7}{{"}, "\\b49\\b"),
+          new Probe("Go template", new String[]{"{{print 7*7}}", "}} {{print 7*7}} {{"}, "\\b49\\b")
+  );
+
+  for (var probe : probes)
+  {
+      for (var payload : probe.payloads())
+      {
+          var rr = http.sendRequest(insertionPoint.buildHttpRequestWithPayload(ByteArray.byteArray(payload)));
+          if (rr.hasResponse())
+          {
+              var body = rr.response().body().toString();
+              if (body.matches("(?s).*" + probe.expectRegex() + ".*") && !body.contains(payload))
+              {
+                  return AuditResult.auditResult(
+                          AuditIssue.auditIssue(
+                                  "Server-Side Template Injection (" + probe.name() + ")",
+                                  "Evaluated with payload: <code>" + api().utilities().htmlUtils().encode(payload) + "</code>",
+                                  "Avoid evaluating user input; sandbox templating.",
+                                  rr.request().url(),
+                                  AuditIssueSeverity.HIGH,
+                                  AuditIssueConfidence.FIRM,
+                                  "",
+                                  "",
+                                  AuditIssueSeverity.HIGH,
+                                  rr
+                          )
+                  );
+              }
+          }
+      }
+  }
+
+  return AuditResult.auditResult();


### PR DESCRIPTION
Add Bambda to detect server-side template injection.

### Bambda Contributions

* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [ ] Bambda compiles and executes as expected
* [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
* [ ] Bambda is in valid yaml format, and has a name, id, function, and location. To ensure this is correct, export the Bambda from your Bambda library in Burp.
