### PR TITLE
Adding a custom action to downgrade upgrade api version

### DIFF
--- a/CustomAction/ApiDowngradeUpgrade.bambda
+++ b/CustomAction/ApiDowngradeUpgrade.bambda
@@ -14,15 +14,7 @@ source: |
   String urlStr = baserequest.url();
   logging().logToOutput("Original URL: " + urlStr);
   /* ── Parse URL ─────────────────────────────────── */
-  java.net.URL parsed;
-  try {
-      parsed = new java.net.URL(urlStr);
-  } catch (Exception e) {
-      logging().logToOutput("URL parse error: " + e.getMessage());
-      return;
-  }
-
-  String path = parsed.getPath();
+  String path = baserequest.path();
   String currentVersion = null;
   for (int i = 1; i <= 5; i++) {
       if (path.contains("/v" + i)) {
@@ -41,9 +33,7 @@ source: |
       String newVersion = "/v" + i;
       if (newVersion.equals(currentVersion)) continue;
       String newPath = path.replace(currentVersion, newVersion);
-      if (parsed.getQuery() != null) {
-          newPath += "?" + parsed.getQuery();
-      }
+
       logging().logToOutput("Sending modified URL: " + newPath);
       var newRequest = baserequest.withPath(newPath);
       var response = api.http().sendRequest(newRequest);

--- a/CustomAction/ApiDowngradeUpgrade.bambda
+++ b/CustomAction/ApiDowngradeUpgrade.bambda
@@ -1,0 +1,58 @@
+id: 8c704eed-cda0-4990-9256-ede2f9002379
+name: api downgrade upgrade
+function: CUSTOM_ACTION
+location: REPEATER
+source: |
+  /**
+  * This Downgrade and Upgrade api version based on your current version
+  *
+  * @author radinanti (https://github.com/radinanti)
+  *
+  **/
+
+  var baserequest = requestResponse.request();
+  String urlStr = baserequest.url();
+  logging().logToOutput("Original URL: " + urlStr);
+  /* ── Parse URL ─────────────────────────────────── */
+  java.net.URL parsed;
+  try {
+      parsed = new java.net.URL(urlStr);
+  } catch (Exception e) {
+      logging().logToOutput("URL parse error: " + e.getMessage());
+      return;
+  }
+
+  String path = parsed.getPath();
+  String currentVersion = null;
+  for (int i = 1; i <= 5; i++) {
+      if (path.contains("/v" + i)) {
+          currentVersion = "/v" + i;
+          break;
+      }
+  }
+  if (currentVersion == null) {
+      logging().logToOutput("No version (/v[NUM]) found in path.");
+      return;
+  }
+  /* ── Log detected version ─────────────────────────────────── */
+  logging().logToOutput("Detected version: " + currentVersion);
+  for (int i = 1; i <= 5; i++) {
+      // This checks v1 to v5 if you want more or less change the numbers
+      String newVersion = "/v" + i;
+      if (newVersion.equals(currentVersion)) continue;
+      String newPath = path.replace(currentVersion, newVersion);
+      if (parsed.getQuery() != null) {
+          newPath += "?" + parsed.getQuery();
+      }
+      logging().logToOutput("Sending modified URL: " + newPath);
+      var newRequest = baserequest.withPath(newPath);
+      var response = api.http().sendRequest(newRequest);
+      if (response == null) {
+          logging().logToOutput(newVersion + " → No response");
+          continue;
+      }
+      int status = response.response().statusCode();
+      logging().logToOutput(newVersion + " → Status Code: " + status);
+      logging().logToOutput(response.response().headerValue("Content-Type"));
+      logging().logToOutput("=====================================================");
+  }

--- a/CustomAction/ApiDowngradeUpgrade.bambda
+++ b/CustomAction/ApiDowngradeUpgrade.bambda
@@ -15,17 +15,13 @@ source: |
   logging().logToOutput("Original URL: " + urlStr);
   /* ── Parse URL ─────────────────────────────────── */
   String path = baserequest.path();
-  String currentVersion = null;
-  for (int i = 1; i <= 5; i++) {
-      if (path.contains("/v" + i)) {
-          currentVersion = "/v" + i;
-          break;
-      }
-  }
-  if (currentVersion == null) {
+  Pattern versionPattern = Pattern.compile("/v(\\d+)");
+  Matcher matcher = versionPattern.matcher(path);
+  if (!matcher.find()) {
       logging().logToOutput("No version (/v[NUM]) found in path.");
       return;
   }
+  String currentVersion = matcher.group(0);
   /* ── Log detected version ─────────────────────────────────── */
   logging().logToOutput("Detected version: " + currentVersion);
   for (int i = 1; i <= 5; i++) {

--- a/CustomAction/README.md
+++ b/CustomAction/README.md
@@ -5,6 +5,48 @@ Please do not manually edit this file, or include any changes to this file in pu
 -->
 # Custom Actions
 Documentation: [Custom actions](https://portswigger.net/burp/documentation/desktop/tools/repeater/http-messages/custom-actions)
+## [ApiDowngradeUpgrade.bambda](https://github.com/PortSwigger/bambdas/blob/main/CustomAction/ApiDowngradeUpgrade.bambda)
+### This Downgrade and Upgrade api version based on your current version
+#### Author: radinanti (https://github.com/radinanti)
+```java
+var baserequest = requestResponse.request();
+String urlStr = baserequest.url();
+logging().logToOutput("Original URL: " + urlStr);
+/* ── Parse URL ─────────────────────────────────── */
+String path = baserequest.path();
+String currentVersion = null;
+for (int i = 1; i <= 5; i++) {
+    if (path.contains("/v" + i)) {
+        currentVersion = "/v" + i;
+        break;
+    }
+}
+if (currentVersion == null) {
+    logging().logToOutput("No version (/v[NUM]) found in path.");
+    return;
+}
+/* ── Log detected version ─────────────────────────────────── */
+logging().logToOutput("Detected version: " + currentVersion);
+for (int i = 1; i <= 5; i++) {
+    // This checks v1 to v5 if you want more or less change the numbers
+    String newVersion = "/v" + i;
+    if (newVersion.equals(currentVersion)) continue;
+    String newPath = path.replace(currentVersion, newVersion);
+
+    logging().logToOutput("Sending modified URL: " + newPath);
+    var newRequest = baserequest.withPath(newPath);
+    var response = api.http().sendRequest(newRequest);
+    if (response == null) {
+        logging().logToOutput(newVersion + " → No response");
+        continue;
+    }
+    int status = response.response().statusCode();
+    logging().logToOutput(newVersion + " → Status Code: " + status);
+    logging().logToOutput(response.response().headerValue("Content-Type"));
+    logging().logToOutput("=====================================================");
+}
+
+```
 ## [BypassFirstRequestValidation.bambda](https://github.com/PortSwigger/bambdas/blob/main/CustomAction/BypassFirstRequestValidation.bambda)
 ### This hides your repeater request behind an innocent GET request. It's useful for bypassing server-level validation sometimes.
 #### Author: James Kettle (https://github.com/albinowax)

--- a/CustomAction/README.md
+++ b/CustomAction/README.md
@@ -14,17 +14,13 @@ String urlStr = baserequest.url();
 logging().logToOutput("Original URL: " + urlStr);
 /* ── Parse URL ─────────────────────────────────── */
 String path = baserequest.path();
-String currentVersion = null;
-for (int i = 1; i <= 5; i++) {
-    if (path.contains("/v" + i)) {
-        currentVersion = "/v" + i;
-        break;
-    }
-}
-if (currentVersion == null) {
+Pattern versionPattern = Pattern.compile("/v(\\d+)");
+Matcher matcher = versionPattern.matcher(path);
+if (!matcher.find()) {
     logging().logToOutput("No version (/v[NUM]) found in path.");
     return;
 }
+String currentVersion = matcher.group(0);
 /* ── Log detected version ─────────────────────────────────── */
 logging().logToOutput("Detected version: " + currentVersion);
 for (int i = 1; i <= 5; i++) {

--- a/CustomAction/README.md
+++ b/CustomAction/README.md
@@ -5,6 +5,7 @@ Please do not manually edit this file, or include any changes to this file in pu
 -->
 # Custom Actions
 Documentation: [Custom actions](https://portswigger.net/burp/documentation/desktop/tools/repeater/http-messages/custom-actions)
+<<<<<<< HEAD
 ## [ApiDowngradeUpgrade.bambda](https://github.com/PortSwigger/bambdas/blob/main/CustomAction/ApiDowngradeUpgrade.bambda)
 ### This Downgrade and Upgrade api version based on your current version
 #### Author: radinanti (https://github.com/radinanti)
@@ -43,6 +44,8 @@ for (int i = 1; i <= 5; i++) {
 }
 
 ```
+=======
+>>>>>>> parent of e6efd18 (Update README.md files)
 ## [BypassFirstRequestValidation.bambda](https://github.com/PortSwigger/bambdas/blob/main/CustomAction/BypassFirstRequestValidation.bambda)
 ### This hides your repeater request behind an innocent GET request. It's useful for bypassing server-level validation sometimes.
 #### Author: James Kettle (https://github.com/albinowax)

--- a/CustomAction/README.md
+++ b/CustomAction/README.md
@@ -5,47 +5,6 @@ Please do not manually edit this file, or include any changes to this file in pu
 -->
 # Custom Actions
 Documentation: [Custom actions](https://portswigger.net/burp/documentation/desktop/tools/repeater/http-messages/custom-actions)
-<<<<<<< HEAD
-## [ApiDowngradeUpgrade.bambda](https://github.com/PortSwigger/bambdas/blob/main/CustomAction/ApiDowngradeUpgrade.bambda)
-### This Downgrade and Upgrade api version based on your current version
-#### Author: radinanti (https://github.com/radinanti)
-```java
-var baserequest = requestResponse.request();
-String urlStr = baserequest.url();
-logging().logToOutput("Original URL: " + urlStr);
-/* ── Parse URL ─────────────────────────────────── */
-String path = baserequest.path();
-Pattern versionPattern = Pattern.compile("/v(\\d+)");
-Matcher matcher = versionPattern.matcher(path);
-if (!matcher.find()) {
-    logging().logToOutput("No version (/v[NUM]) found in path.");
-    return;
-}
-String currentVersion = matcher.group(0);
-/* ── Log detected version ─────────────────────────────────── */
-logging().logToOutput("Detected version: " + currentVersion);
-for (int i = 1; i <= 5; i++) {
-    // This checks v1 to v5 if you want more or less change the numbers
-    String newVersion = "/v" + i;
-    if (newVersion.equals(currentVersion)) continue;
-    String newPath = path.replace(currentVersion, newVersion);
-
-    logging().logToOutput("Sending modified URL: " + newPath);
-    var newRequest = baserequest.withPath(newPath);
-    var response = api.http().sendRequest(newRequest);
-    if (response == null) {
-        logging().logToOutput(newVersion + " → No response");
-        continue;
-    }
-    int status = response.response().statusCode();
-    logging().logToOutput(newVersion + " → Status Code: " + status);
-    logging().logToOutput(response.response().headerValue("Content-Type"));
-    logging().logToOutput("=====================================================");
-}
-
-```
-=======
->>>>>>> parent of e6efd18 (Update README.md files)
 ## [BypassFirstRequestValidation.bambda](https://github.com/PortSwigger/bambdas/blob/main/CustomAction/BypassFirstRequestValidation.bambda)
 ### This hides your repeater request behind an innocent GET request. It's useful for bypassing server-level validation sometimes.
 #### Author: James Kettle (https://github.com/albinowax)


### PR DESCRIPTION
### Bambda Contributions

* [ ] Bambda has a valid [header](https://github.com/PortSwigger/bambdas/blob/73077e7ff3f6fac9db7dc95c0a00bd842b6bb64c/Proxy/HTTP/FilterOnCookieValue.bambda#L1-L5), featuring an `@author` annotation and suitable description
* [ ] Bambda compiles and executes as expected
* [ ] Only .bambda files have been added or modified (README.md files are automatically updated / generated after PR merge)
* [ ] Bambda is in valid yaml format, and has a name, id, function, and location. To ensure this is correct, export the Bambda from your Bambda library in Burp.


This custom action detects the API version from the path and upgrades downgrades it. You can change the minimum and maximum version numbers in the code.