### PR TITLE
security: replace vulnerable webhook steps with shared input sanitizer

### DIFF
--- a/.github/workflows/issue-webhook.yml
+++ b/.github/workflows/issue-webhook.yml
@@ -10,14 +10,33 @@ jobs:
     if: github.event.repository.fork == false
 
     steps:
-      - name: Push to Webhook
-        run: |
-          echo $AUTHOR $TITLE $LINK 
-          curl "$WEBHOOK" -X POST -H "Content-Type: application/json" -H "Authorization: $AUTH_TOKEN" -d "$AUTHOR"$'\n'"$TITLE"$'\n'"$LINK"
-        env:
-          AUTHOR: ${{ github.event.issue.user.login }}
-          TITLE: ${{ github.event.issue.title }}
-          LINK: ${{ github.event.issue.html_url }}
-          WEBHOOK: ${{ secrets.WEBHOOK_URL }}
-          AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
-        
+      - name: Harden runner
+        uses: portswigger-tim/safer-runner-action@b2208f653b6bf422e08501155f4df82bad008184 # v1.2.2
+        with:
+          mode: enforce
+          allowed-domains: 'integrations.zoom.us'
+          disable-sudo: 'true'
+          disable-docker: 'true'
+          block-risky-github-subdomains: 'true'
+
+      - name: Sanitize inputs
+        id: sanitize
+        uses: PortSwigger/shared-workflows/sanitize-inputs@ff879d3c7b4476af5ed83d7d81438c7258217644 # v1.0.0
+        with:
+          type: bambda
+          title: ${{ github.event.issue.title }}
+          author: ${{ github.event.issue.user.login }}
+          url: ${{ github.event.issue.html_url }}
+
+      - name: Post to webhook
+        if: steps.sanitize.outputs.error_message == ''
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
+        with:
+          url: ${{ secrets.WEBHOOK_URL }}
+          method: POST
+          contentType: text/plain
+          customHeaders: '{"Authorization": "${{ secrets.AUTH_TOKEN }}"}'
+          data: |
+            ${{ steps.sanitize.outputs.author }}
+            ${{ steps.sanitize.outputs.title }}
+            ${{ steps.sanitize.outputs.url }}

--- a/.github/workflows/pr-webhook.yml
+++ b/.github/workflows/pr-webhook.yml
@@ -10,13 +10,33 @@ jobs:
     if: github.event.repository.fork == false
 
     steps:
-      - name: Push to Webhook
-        run: |
-          echo $AUTHOR $TITLE $LINK 
-          curl "$WEBHOOK" -X POST -H "Content-Type: application/json" -H "Authorization: $AUTH_TOKEN" -d "$AUTHOR"$'\n'"$TITLE"$'\n'"$LINK"
-        env:
-          AUTHOR: ${{ github.event.pull_request.user.login }}
-          TITLE: ${{ github.event.pull_request.title }}
-          LINK: ${{ github.event.pull_request.html_url }}
-          WEBHOOK: ${{ secrets.WEBHOOK_URL }}
-          AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
+      - name: Harden runner
+        uses: portswigger-tim/safer-runner-action@b2208f653b6bf422e08501155f4df82bad008184 # v1.2.2
+        with:
+          mode: enforce
+          allowed-domains: 'integrations.zoom.us'
+          disable-sudo: 'true'
+          disable-docker: 'true'
+          block-risky-github-subdomains: 'true'
+
+      - name: Sanitize inputs
+        id: sanitize
+        uses: PortSwigger/shared-workflows/sanitize-inputs@ff879d3c7b4476af5ed83d7d81438c7258217644 # v1.0.0
+        with:
+          type: bambda
+          title: ${{ github.event.pull_request.title }}
+          author: ${{ github.event.pull_request.user.login }}
+          url: ${{ github.event.pull_request.html_url }}
+
+      - name: Post to webhook
+        if: steps.sanitize.outputs.error_message == ''
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
+        with:
+          url: ${{ secrets.WEBHOOK_URL }}
+          method: POST
+          contentType: text/plain
+          customHeaders: '{"Authorization": "${{ secrets.AUTH_TOKEN }}"}'
+          data: |
+            ${{ steps.sanitize.outputs.author }}
+            ${{ steps.sanitize.outputs.title }}
+            ${{ steps.sanitize.outputs.url }}


### PR DESCRIPTION
## Summary
- Add hardened runner (`portswigger-tim/safer-runner-action`) to both issue and PR webhook workflows
- Replace direct shell execution of user-controlled inputs (`echo`/`curl` in `run:` steps) with shared sanitization action (`PortSwigger/shared-workflows/sanitize-inputs`) and `fjogeleit/http-request-action`
- Allowlist `integrations.zoom.us` in the hardened runner for webhook delivery
- Preserves existing fork guard and trigger types (`opened, reopened`)

This eliminates command injection risk from malicious issue titles, PR titles, and usernames.

## Test plan
- [ ] Merge and create a test issue to verify the webhook notification is received
- [ ] Verify the hardened runner does not block the webhook POST to integrations.zoom.us
- [ ] Verify the sanitized payload format matches what the webhook consumer expects

🤖 Generated with [Claude Code](https://claude.com/claude-code)